### PR TITLE
fix(job-attachment): Refactor bucket creation and ensure complete resource deletion

### DIFF
--- a/src/deadline_test_fixtures/cloudformation/job_attachments_bootstrap_stack.py
+++ b/src/deadline_test_fixtures/cloudformation/job_attachments_bootstrap_stack.py
@@ -6,12 +6,10 @@ from .cfn import (
     BucketPolicy,
     CfnStack,
 )
-from .util import create_secure_bucket
 
 
 class JobAttachmentsBootstrapStack(CfnStack):  # pragma: no cover
     bucket: Bucket
-    log_bucket: Bucket
     bucket_policy: BucketPolicy
 
     def __init__(
@@ -23,13 +21,37 @@ class JobAttachmentsBootstrapStack(CfnStack):  # pragma: no cover
     ) -> None:
         super().__init__(name=name, description=description)
 
-        self.bucket, self.log_bucket, self.bucket_policy = create_secure_bucket(
-            self,
-            "JobAttachmentBucket",
-            bucket_kwargs={
-                "bucket_name": bucket_name,
+        self.bucket = Bucket(
+            stack=self,
+            logical_name="JobAttachmentBucket",
+            bucket_name=bucket_name,
+            versioning=False,
+            encryption={
+                "ServerSideEncryptionConfiguration": [
+                    {"ServerSideEncryptionByDefault": {"SSEAlgorithm": "AES256"}},
+                ],
             },
-            log_bucket_kwargs={
-                "bucket_name": f"{bucket_name}-logs",
+            update_replace_policy="Delete",
+            deletion_policy="Delete",
+        )
+
+        self.bucket_policy = BucketPolicy(
+            stack=self,
+            logical_name="JobAttachmentBucketPolicy",
+            bucket=self.bucket,
+            policy_document={
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Action": "s3:*",
+                        "Effect": "Deny",
+                        "Principal": "*",
+                        "Resource": [
+                            self.bucket.arn,
+                            self.bucket.arn_for_objects(),
+                        ],
+                        "Condition": {"Bool": {"aws:SecureTransport": "false"}},
+                    },
+                ],
             },
         )

--- a/src/deadline_test_fixtures/fixtures.py
+++ b/src/deadline_test_fixtures/fixtures.py
@@ -499,7 +499,7 @@ def deploy_job_attachment_resources() -> Generator[JobAttachmentManager, None, N
         JobAttachmentManager: Class to manage Job Attachments resources
     """
     manager = JobAttachmentManager(
-        s3_resource=boto3.resource("s3"),
+        s3_client=boto3.client("s3"),
         cfn_client=boto3.client("cloudformation"),
         deadline_client=DeadlineClient(boto3.client("deadline")),
         account_id=os.environ["SERVICE_ACCOUNT_ID"],


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
This PR tries to address two issues:
- We were using `create_secure_bucket()` utility function to create an S3 bucket and bucket policy for Job Attachment integration test, which had extraneous attributes and additional log bucket, and it felt overkill for what we actually needed. 
- Upon Job Attachment test completion, I encountered an issue where the CFN stack failed to delete due to lingering object versions in the bucket, despite the Bucket Versioning being suspended.

### What was the solution? (How)
- Replaced the usage of `create_secure_bucket()` with direct bucket and bucket policy creation.
- Added a deletion routine that ensures all versions of objects in the bucket are deleted to prevent `DELETE_FAILED` state with the CFN stack.

### What is the impact of this change?
- Test resources for Job Attachment are a bit cleaned up.
- The CFN stack for testing can be deleted successfully.

### How was this change tested?
- Ran `hatch run lint && hatch run test`
- Ran Job Attachment integ test to ensure that all tests pass with this test-fixtures changes. See the client lib PR: https://github.com/casillas2/deadline-cloud/pull/26

### Was this change documented?
No.

### Is this a breaking change?
No.
