### PR TITLE
fix: set extra model paths

### DIFF
--- a/src/deadline_test_fixtures/fixtures.py
+++ b/src/deadline_test_fixtures/fixtures.py
@@ -104,7 +104,10 @@ def deadline_client(
     if endpoint_url:
         LOG.info(f"Using Amazon Deadline Cloud endpoint: {endpoint_url}")
 
-    return DeadlineClient(boto3.client("deadline", endpoint_url=endpoint_url))
+    session = boto3.Session()
+    session._loader.search_paths.extend([install_service_model])
+
+    return DeadlineClient(session.client("deadline", endpoint_url=endpoint_url))
 
 
 @pytest.fixture(scope="session")
@@ -160,11 +163,11 @@ def service_model() -> Generator[ServiceModel, None, None]:
 
 
 @pytest.fixture(scope="session")
-def install_service_model(service_model: ServiceModel) -> Generator[None, None, None]:
+def install_service_model(service_model: ServiceModel) -> Generator[str, None, None]:
     LOG.info("Installing service model and configuring boto to use it for API calls")
     with service_model.install() as model_path:
         LOG.info(f"Installed service model to {model_path}")
-        yield
+        yield model_path
 
 
 @pytest.fixture(scope="session")

--- a/src/deadline_test_fixtures/models.py
+++ b/src/deadline_test_fixtures/models.py
@@ -103,7 +103,7 @@ class ServiceModel:
                 json_path.parent.mkdir(parents=True)
                 json_path.write_text(src_file.read_text())
                 os.environ["AWS_DATA_PATH"] = tmpdir
-                yield str(json_path)
+                yield str(tmpdir)
         finally:
             if old_aws_data_path:
                 os.environ["AWS_DATA_PATH"] = old_aws_data_path


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
After the pytests environment is initiated AWS_DATA_PATH changes will not be recognized.

### What was the solution? (How)
Add extra search paths when creating the session so that the `LOCAL_MODEL_PATH` and `DEADLINE_SERVICE_MODEL_S3_URI` models can be found.

### What is the impact of this change?
Allows user set model paths via env vars to be found

### How was this change tested?
```
hatch run lint
hatch run test
```

Removed models from my local system and confirmed that setting them via the environment variables worked.

### Was this change documented?
No

### Is this a breaking change?
No