### PR TITLE
chore: Added JobRunAsUser to Queue.create

### DIFF
--- a/src/deadline_test_fixtures/deadline/resources.py
+++ b/src/deadline_test_fixtures/deadline/resources.py
@@ -11,7 +11,7 @@ from typing import Any, Callable, Literal, TYPE_CHECKING
 from botocore.client import BaseClient
 
 from .client import DeadlineClient
-from ..models import JobAttachmentSettings
+from ..models import JobAttachmentSettings, JobRunAsUser
 from ..util import call_api, clean_kwargs, wait_for
 
 if TYPE_CHECKING:
@@ -62,6 +62,7 @@ class Queue:
         farm: Farm,
         role_arn: str | None = None,
         job_attachments: JobAttachmentSettings | None = None,
+        job_run_as_user: JobRunAsUser,
         raw_kwargs: dict | None = None,
     ) -> Queue:
         kwargs = clean_kwargs(
@@ -72,6 +73,7 @@ class Queue:
                 "jobAttachmentSettings": (
                     job_attachments.as_queue_settings() if job_attachments else None
                 ),
+                "jobRunAsUser": job_run_as_user,
                 **(raw_kwargs or {}),
             }
         )

--- a/src/deadline_test_fixtures/fixtures.py
+++ b/src/deadline_test_fixtures/fixtures.py
@@ -31,6 +31,8 @@ from .deadline.worker import (
 from .models import (
     CodeArtifactRepositoryInfo,
     JobAttachmentSettings,
+    JobRunAsUser,
+    PosixSessionUser,
     ServiceModel,
     S3Object,
 )
@@ -51,6 +53,10 @@ class BootstrapResources:
     job_attachments: JobAttachmentSettings | None = field(init=False, default=None)
     job_attachments_bucket_name: InitVar[str | None] = None
     job_attachments_root_prefix: InitVar[str | None] = None
+
+    job_run_as_user: JobRunAsUser = field(
+        default_factory=lambda: JobRunAsUser(PosixSessionUser("", ""))
+    )
 
     def __post_init__(
         self,
@@ -284,6 +290,7 @@ def deadline_resources(
             farm=farm,
             job_attachments=bootstrap_resources.job_attachments,
             role_arn=bootstrap_resources.session_role_arn,
+            job_run_as_user=bootstrap_resources.job_run_as_user,
         )
         fleet = Fleet.create(
             client=deadline_client,

--- a/src/deadline_test_fixtures/job_attachment_manager.py
+++ b/src/deadline_test_fixtures/job_attachment_manager.py
@@ -13,6 +13,8 @@ from .deadline import (
     Queue,
 )
 
+from .models import JobRunAsUser, PosixSessionUser
+
 
 @dataclass
 class JobAttachmentManager:
@@ -56,11 +58,13 @@ class JobAttachmentManager:
                 client=self.deadline_client,
                 display_name="job_attachments_test_queue",
                 farm=self.farm,
+                job_run_as_user=JobRunAsUser(PosixSessionUser("", "")),
             )
             self.queue_with_no_settings = Queue.create(
                 client=self.deadline_client,
                 display_name="job_attachments_test_no_settings_queue",
                 farm=self.farm,
+                job_run_as_user=JobRunAsUser(PosixSessionUser("", "")),
             )
             self.stack.deploy(cfn_client=self.cfn_client)
         except (ClientError, WaiterError):

--- a/src/deadline_test_fixtures/models.py
+++ b/src/deadline_test_fixtures/models.py
@@ -26,6 +26,17 @@ class JobAttachmentSettings:
 
 
 @dataclass(frozen=True)
+class PosixSessionUser:
+    user: str
+    group: str
+
+
+@dataclass(frozen=True)
+class JobRunAsUser:
+    posix: PosixSessionUser
+
+
+@dataclass(frozen=True)
 class CodeArtifactRepositoryInfo:
     region: str
     domain: str

--- a/test/unit/deadline/test_resources.py
+++ b/test/unit/deadline/test_resources.py
@@ -19,6 +19,7 @@ from deadline_test_fixtures import (
     TaskStatus,
 )
 from deadline_test_fixtures.deadline import resources as mod
+from deadline_test_fixtures.models import JobRunAsUser, PosixSessionUser
 
 
 @pytest.fixture(autouse=True)
@@ -97,6 +98,7 @@ class TestQueue:
         job_attachments = JobAttachmentSettings(bucket_name="bucket", root_prefix="root")
         mock_client = MagicMock()
         mock_client.create_queue.return_value = {"queueId": queue_id}
+        job_run_as_user = JobRunAsUser(posix=PosixSessionUser(user="test-user", group="test-group"))
 
         # WHEN
         result = Queue.create(
@@ -105,6 +107,7 @@ class TestQueue:
             farm=farm,
             role_arn=role_arn,
             job_attachments=job_attachments,
+            job_run_as_user=job_run_as_user,
         )
 
         # THEN
@@ -114,6 +117,7 @@ class TestQueue:
             farmId=farm.id,
             roleArn=role_arn,
             jobAttachmentSettings=job_attachments.as_queue_settings(),
+            jobRunAsUser=job_run_as_user,
         )
 
     def test_delete(self, queue: Queue) -> None:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
`JobRunAsUser` is becoming a required field for `create-queue`, but we omit it.

### What was the solution? (How)
Add said field to said calls.

### What is the impact of this change?
This project will not break once the change is made to the model.

### How was this change tested?
```sh
hatch run fmt && hatch run lint && hatch build && hatch run test
```

### Was this change documented?
N/A

### Is this a breaking change?
No, its' a fixing change.