### PR TITLE
fix: convert JobRunAsUser to dict before passing to boto call

### DIFF
--- a/src/deadline_test_fixtures/__init__.py
+++ b/src/deadline_test_fixtures/__init__.py
@@ -11,7 +11,6 @@ from .deadline import (
     Farm,
     Fleet,
     PipInstall,
-    PosixUser,
     Queue,
     QueueFleetAssociation,
     TaskStatus,
@@ -29,6 +28,8 @@ from .job_attachment_manager import JobAttachmentManager
 from .models import (
     CodeArtifactRepositoryInfo,
     JobAttachmentSettings,
+    JobRunAsUser,
+    PosixSessionUser,
     S3Object,
     ServiceModel,
 )
@@ -53,8 +54,9 @@ __all__ = [
     "Job",
     "JobAttachmentSettings",
     "JobAttachmentManager",
+    "JobRunAsUser",
     "PipInstall",
-    "PosixUser",
+    "PosixSessionUser",
     "S3Object",
     "ServiceModel",
     "StubDeadlineClient",

--- a/src/deadline_test_fixtures/deadline/__init__.py
+++ b/src/deadline_test_fixtures/deadline/__init__.py
@@ -17,7 +17,6 @@ from .worker import (
     DockerContainerWorker,
     EC2InstanceWorker,
     PipInstall,
-    PosixUser,
 )
 
 __all__ = [
@@ -32,7 +31,6 @@ __all__ = [
     "Fleet",
     "Job",
     "PipInstall",
-    "PosixUser",
     "Queue",
     "QueueFleetAssociation",
     "TaskStatus",

--- a/src/deadline_test_fixtures/deadline/resources.py
+++ b/src/deadline_test_fixtures/deadline/resources.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import datetime
 import json
 import logging
-from dataclasses import dataclass, fields
+from dataclasses import asdict, dataclass, fields
 from enum import Enum
 from typing import Any, Callable, Literal, TYPE_CHECKING
 
@@ -73,7 +73,7 @@ class Queue:
                 "jobAttachmentSettings": (
                     job_attachments.as_queue_settings() if job_attachments else None
                 ),
-                "jobRunAsUser": job_run_as_user,
+                "jobRunAsUser": asdict(job_run_as_user),
                 **(raw_kwargs or {}),
             }
         )

--- a/src/deadline_test_fixtures/deadline/worker.py
+++ b/src/deadline_test_fixtures/deadline/worker.py
@@ -19,7 +19,11 @@ from dataclasses import dataclass, field, InitVar, replace
 from typing import Any, ClassVar, Optional, cast
 
 from .client import DeadlineClient
-from ..models import PipInstall, ServiceModel
+from ..models import (
+    PipInstall,
+    PosixSessionUser,
+    ServiceModel,
+)
 from ..util import call_api, wait_for
 
 LOG = logging.getLogger(__name__)
@@ -111,12 +115,6 @@ class CommandResult:  # pragma: no cover
 
 
 @dataclass(frozen=True)
-class PosixUser:
-    user: str
-    group: str
-
-
-@dataclass(frozen=True)
 class DeadlineWorkerConfiguration:
     farm_id: str
     fleet_id: str
@@ -125,7 +123,9 @@ class DeadlineWorkerConfiguration:
     group: str
     allow_shutdown: bool
     worker_agent_install: PipInstall
-    job_users: list[PosixUser] = field(default_factory=lambda: [PosixUser("jobuser", "jobuser")])
+    job_users: list[PosixSessionUser] = field(
+        default_factory=lambda: [PosixSessionUser("jobuser", "jobuser")]
+    )
     start_service: bool = False
     no_install_service: bool = False
     service_model: ServiceModel | None = None

--- a/test/unit/deadline/test_resources.py
+++ b/test/unit/deadline/test_resources.py
@@ -2,7 +2,7 @@
 
 import datetime
 import json
-from dataclasses import replace
+from dataclasses import asdict, replace
 from typing import Any, Generator, cast
 from unittest.mock import MagicMock, call, patch
 
@@ -117,7 +117,7 @@ class TestQueue:
             farmId=farm.id,
             roleArn=role_arn,
             jobAttachmentSettings=job_attachments.as_queue_settings(),
-            jobRunAsUser=job_run_as_user,
+            jobRunAsUser=asdict(job_run_as_user),
         )
 
     def test_delete(self, queue: Queue) -> None:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We recently added a required `job_run_as_user` field to our Queue creation but passed the incorrect type to our boto CreateQueue call (JobRunAsUser instead of dict)

Note: I gave the OK to release the previous changes as a patch version, but I was wrong, it should've been a minor version bump because users need to update calls to `Queue.create` to use the new required param. Since we're already in a situation with a breaking change as a patch version, I'll also release this change as a patch version since it fixes a bug in the last patch.

### What was the solution? (How)
Convert the dataclass to a dict in our boto call

### What is the impact of this change?
It works

### How was this change tested?
Ran worker agent integ tests. See https://github.com/casillas2/deadline-cloud-worker-agent/pull/57

### Was this change documented?
No

### Is this a breaking change?
No