### PR TITLE
fix: increase timeout for fleet creation

### DIFF
--- a/src/deadline_test_fixtures/deadline/resources.py
+++ b/src/deadline_test_fixtures/deadline/resources.py
@@ -143,6 +143,8 @@ class Fleet:
             client=client,
             desired_status="ACTIVE",
             allowed_statuses=set(["CREATE_IN_PROGRESS"]),
+            interval_s=10,
+            max_retries=6 * 5,  # 5 minutes to allow CMF fleet creation to complete
         )
 
         return fleet

--- a/test/unit/deadline/test_resources.py
+++ b/test/unit/deadline/test_resources.py
@@ -165,6 +165,8 @@ class TestFleet:
             client=mock_client,
             desired_status="ACTIVE",
             allowed_statuses=set(["CREATE_IN_PROGRESS"]),
+            interval_s=10,
+            max_retries=6 * 5,  # 5 minutes for CMF fleet creation
         )
 
     def test_delete(self, fleet: Fleet) -> None:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The Worker Agent integration tests failed to setup due to timeouts when waiting for fleet status to become `ACTIVE` after creating it.

### What was the solution? (How)
Use the boto waiter for fleet creation instead of rolling our own poller.

### What is the impact of this change?
Worker Agent integration tests should be able to get passed fleet setup again.

### How was this change tested?
Creating a fleet using this package in a Python shell:

```
>>> fleet = deadline.Fleet.create(client=client, display_name="test-fleet", farm=farm, configuration={"customerManaged": { "mode": "NO_SCALING", "workerRequirements": { "vCpuCount": {"min":1}, "memoryMiB": {"min": 1024}, "osFamily": "linux", "cpuArchitectureType": "x86_64"}}}, max_worker_count=1, role_arn="<my_role>")
>>> fleet.id
'fleet-531fd8d9bb7a405db488d16b35682444'
>>> client.get_fleet(farmId=farm.id, fleetId=fleet.id)["status"]
'ACTIVE'
```

### Was this change documented?
N/A

### Is this a breaking change?
No