### PR TITLE
fix: increase ec2 instance_status_ok waiter timeout thresholds

### DIFF
--- a/src/deadline_test_fixtures/deadline/worker.py
+++ b/src/deadline_test_fixtures/deadline/worker.py
@@ -342,7 +342,10 @@ runuser --login {self.configuration.user} --command 'python3 -m venv $HOME/.venv
 
         LOG.info(f"Waiting for EC2 instance {self.instance_id} status to be OK")
         instance_running_waiter = self.ec2_client.get_waiter("instance_status_ok")
-        instance_running_waiter.wait(InstanceIds=[self.instance_id])
+        instance_running_waiter.wait(
+            InstanceIds=[self.instance_id],
+            WaiterConfig={"Delay": 15, "MaxAttempts": 60},
+        )
         LOG.info(f"EC2 instance {self.instance_id} status is OK")
 
     def _start_worker_agent(self) -> None:  # pragma: no cover


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The `EC2InstanceWorker` class can sometimes error on a retry/timeout when waiting for the EC2 instance status to become ok.

```
botocore.exceptions.WaiterError: Waiter InstanceStatusOk failed: Max attempts exceeded
```

### What was the solution? (How)

Increase the thresholds from their defaults:

| retry configurable | default | new value |
| --- | --- | --- |
| `sleep_amount` | 15 | 15 |
| `max_attempts` | 40 | 60 |

This effectively goes increases the total time for the EC2 instance to become ready from 10 minutes &rarr; 15 minutes.

### What is the impact of this change?

There is a lower probability of the tests failing due to the EC2 instance not being ready in within the threshold allowed by the boto3 waiter.

### How was this change tested?

Ran the worker agent tests using these code changes

### Was this change documented?

No

### Is this a breaking change?

No