### PR TITLE
fix: apply CreateQueue API changes

### DIFF
--- a/src/deadline_test_fixtures/fixtures.py
+++ b/src/deadline_test_fixtures/fixtures.py
@@ -56,7 +56,9 @@ class BootstrapResources:
     job_attachments_root_prefix: InitVar[str | None] = None
 
     job_run_as_user: JobRunAsUser = field(
-        default_factory=lambda: JobRunAsUser(PosixSessionUser("", ""))
+        default_factory=lambda: JobRunAsUser(
+            posix=PosixSessionUser("", ""), runAs="WORKER_AGENT_USER"
+        )
     )
 
     def __post_init__(

--- a/src/deadline_test_fixtures/job_attachment_manager.py
+++ b/src/deadline_test_fixtures/job_attachment_manager.py
@@ -58,13 +58,17 @@ class JobAttachmentManager:
                 client=self.deadline_client,
                 display_name="job_attachments_test_queue",
                 farm=self.farm,
-                job_run_as_user=JobRunAsUser(PosixSessionUser("", "")),
+                job_run_as_user=JobRunAsUser(
+                    posix=PosixSessionUser("", ""), runAs="WORKER_AGENT_USER"
+                ),
             )
             self.queue_with_no_settings = Queue.create(
                 client=self.deadline_client,
                 display_name="job_attachments_test_no_settings_queue",
                 farm=self.farm,
-                job_run_as_user=JobRunAsUser(PosixSessionUser("", "")),
+                job_run_as_user=JobRunAsUser(
+                    posix=PosixSessionUser("", ""), runAs="WORKER_AGENT_USER"
+                ),
             )
             self.stack.deploy(cfn_client=self.cfn_client)
         except (ClientError, WaiterError):

--- a/src/deadline_test_fixtures/models.py
+++ b/src/deadline_test_fixtures/models.py
@@ -10,7 +10,7 @@ from abc import ABC, abstractproperty
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Generator
+from typing import Generator, Literal
 
 
 @dataclass(frozen=True)
@@ -34,6 +34,7 @@ class PosixSessionUser:
 @dataclass(frozen=True)
 class JobRunAsUser:
     posix: PosixSessionUser
+    runAs: Literal["QUEUE_CONFIGURED_USER", "WORKER_AGENT_USER"]
 
 
 @dataclass(frozen=True)

--- a/test/unit/deadline/test_resources.py
+++ b/test/unit/deadline/test_resources.py
@@ -98,7 +98,10 @@ class TestQueue:
         job_attachments = JobAttachmentSettings(bucket_name="bucket", root_prefix="root")
         mock_client = MagicMock()
         mock_client.create_queue.return_value = {"queueId": queue_id}
-        job_run_as_user = JobRunAsUser(posix=PosixSessionUser(user="test-user", group="test-group"))
+        job_run_as_user = JobRunAsUser(
+            posix=PosixSessionUser(user="test-user", group="test-group"),
+            runAs="QUEUE_CONFIGURED_USER",
+        )
 
         # WHEN
         result = Queue.create(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The `CreateQueue` API has changed and now requires a new `"jobRunAsUser"` &rarr; `"runAs"` field in the request (one of two values: `QUEUE_CONFIGURED_USER` or `WORKER_AGENT_USER`).

### What was the solution? (How)

Updated the test fixtures to pass this new API request field.

### What is the impact of this change?

Consumers of `deadline-cloud-test-fixtures` can now create queues using the new API shape.

### How was this change tested?

Tested this with casillas2/deadline-cloud-worker-agent#133 and confirmed that this change uses the new API fields when making `CreateQueue` requests.

### Was this change documented?

No

### Is this a breaking change?

No