### PR TITLE
chore(deps): pin coverage==7.*

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,4 +1,4 @@
-coverage[toml] == 7.4.*
+coverage[toml] == 7.*
 pytest == 7.4.*
 pytest-cov == 4.1.*
 pytest-timeout == 2.2.*


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Our CIs are failing to fetch `coverage~=7.4`

### What was the solution? (How)

Pin to `coverage == 7.*`

### What is the impact of this change?

CIs will resume working

### How was this change tested?

Ran:

```sh
hatch env prune
hatch run fmt
hatch run lint
hatch build
hatch run test
```

### Was this change documented?

No

### Is this a breaking change?

No