### PR TITLE
chore: add readme and license to published artifacts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,8 @@ authors = [
   {name = "Amazon Web Services"},
 ]
 dynamic = ["version"]
+license = "Apache-2.0"
+readme = "README.md"
 requires-python = ">=3.9"
 # https://pypi.org/classifiers/
 classifiers = [


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

#### 1. Publishing Error

We encountered a failure trying to publish to PyPI:

```
ERROR    `long_description` has syntax errors in markup and would not be        
         rendered on PyPI.
```

#### 2. Missing license

The package was also missing a license in `pyproject.toml`.

### What was the solution? (How)

1.  Discovered in pypa/gh-action-pypi-publish#162, the fix was to add the following to `pyproject.toml`:

    ```toml
    [project]
    readme = "README.md"
    ```

2.  Added our license to `pyproject.toml`

### What is the impact of this change?

We will be able to publish to PyPI without the above failure.

### How was this change tested?

Ran `hatch build` and inspected the built archives. Confirmed the `README.md` was included.

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*