### PR TITLE
fix: stop using removed worker agent CLI argument

### DIFF
--- a/src/deadline_test_fixtures/deadline/worker.py
+++ b/src/deadline_test_fixtures/deadline/worker.py
@@ -362,7 +362,7 @@ runuser --login {self.configuration.user} --command 'python3 -m venv $HOME/.venv
         cmd_result = self.send_command(
             " && ".join(
                 [
-                    f"nohup runuser --login {self.configuration.user} -c 'AWS_DEFAULT_REGION={self.configuration.region} deadline-worker-agent --allow-instance-profile >/dev/null 2>&1 &'",
+                    f"nohup runuser --login {self.configuration.user} -c 'AWS_DEFAULT_REGION={self.configuration.region} deadline-worker-agent > /tmp/worker-agent-stdout.txt 2>&1 &'",
                     # Verify Worker is still running
                     "echo Waiting 5s for agent to get started",
                     "sleep 5",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

1.  The worker agent was modified in aws-deadline/deadline-cloud-worker-agent#277 to remove deprecate command-line arguments including `--allow-instance-profile` which is used by the test fixtures.
2.  Standard output from the `deadline-worker-agent` was redirected to `/dev/null` which made forensic analysis challenging

### What was the solution? (How)

1.  Remove the no-longer-available `--allow-instance-profile` when launching `deadline-worker-agent`
2. Redirect standard output to `/tmp/worker-agent-stdout.txt`

### What is the impact of this change?

The worker agent will startup without errors when running tests which use these test fixtures

### How was this change tested?

*   Ran the build
*   E2E tests in progress...

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*