### PR TITLE
fix!: set AWS_ENDPOINT_URL_DEADLINE after installing service model 

### DIFF
--- a/src/deadline_test_fixtures/example_config.sh
+++ b/src/deadline_test_fixtures/example_config.sh
@@ -30,6 +30,10 @@ export CODEARTIFACT_REGION
 
 # --- OPTIONAL --- #
 
+# The AWS region to use
+# Falls back to AWS_DEFAULT_REGION, then defaults to us-west-2
+export REGION
+
 # Extra local path for boto to look for AWS models in
 # Does not apply to the worker
 export AWS_DATA_PATH
@@ -38,9 +42,10 @@ export AWS_DATA_PATH
 # Default is to pip install the latest "deadline-cloud-worker-agent" package
 export WORKER_AGENT_WHL_PATH
 
+# DEPRECATED: Use REGION instead
 # The AWS region to configure the worker for
 # Falls back to AWS_DEFAULT_REGION, then defaults to us-west-2
-export WORKER_REGION
+# export WORKER_REGION
 
 # The POSIX user to configure the worker for
 # Defaults to "deadline-worker"

--- a/test/unit/deadline/test_worker.py
+++ b/test/unit/deadline/test_worker.py
@@ -21,7 +21,6 @@ from deadline_test_fixtures import (
     EC2InstanceWorker,
     PipInstall,
     S3Object,
-    ServiceModel,
 )
 
 
@@ -59,11 +58,6 @@ def region(boto_config: dict[str, str]) -> str:
 
 
 @pytest.fixture
-def deadline_client() -> MagicMock:
-    return MagicMock()
-
-
-@pytest.fixture
 def worker_config(region: str) -> DeadlineWorkerConfiguration:
     return DeadlineWorkerConfiguration(
         farm_id="farm-123",
@@ -86,11 +80,7 @@ def worker_config(region: str) -> DeadlineWorkerConfiguration:
             ("/packages/manifest.json", "/tmp/manifest.json"),
             ("/aws/models/deadline.json", "/tmp/deadline.json"),
         ],
-        service_model=ServiceModel(
-            file_path="/tmp/deadline/1234-12-12/service-2.json",
-            api_version="1234-12-12",
-            service_name="deadline",
-        ),
+        service_model_path="/path/to/service-2.json",
     )
 
 
@@ -151,7 +141,6 @@ class TestEC2InstanceWorker:
     @pytest.fixture
     def worker(
         self,
-        deadline_client: MagicMock,
         worker_config: DeadlineWorkerConfiguration,
         subnet_id: str,
         security_group_id: str,
@@ -166,7 +155,6 @@ class TestEC2InstanceWorker:
             s3_client=boto3.client("s3"),
             ec2_client=boto3.client("ec2"),
             ssm_client=boto3.client("ssm"),
-            deadline_client=deadline_client,
             configuration=worker_config,
         )
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Main issue:
- With the release of botocore that includes our service model, our method of configuring service model is no longer sufficient to contact endpoints other than the one included in botocore. We need to set `AWS_ENDPOINT_URL_DEADLINE` to tell boto that we want requests to Deadline Cloud to go to a different endpoint.

Small issues:
- The test fixtures code that copies the service model from the test runner machine to the worker machine does not support gzip files, which is the format that service models included botocore are in.
- The `KEEP_WORKER_AFTER_FAILURE` configuration was not working, workers are still shutting down after failing to start
- The `WORKER_REGION` configuration is unnecessarily specific to the worker. The region can be applied to all components created by the test fixtures.

### What was the solution? (How)
- Set `AWS_ENDPOINT_URL_DEADLINE` whenever we install a service model
- Support gzip (`.json.gz`) service model files
    - The `ServiceModel` class was responsible for too many things. Removed the file paths and the AWS CLI commands from the class to simplify the code.
- Make `KEEP_WORKER_AFTER_FAILURE` actually keep the worker around after failing
- Deprecate `WORKER_REGION` and use `REGION` instead

### What is the impact of this change?
- We can contact different Deadline Cloud endpoints for our tests
- We support gzip service model files
- `KEEP_WORKER_AFTER_FAILURE` works
- `WORKER_REGION` configuration is deprecated

### How was this change tested?
- `hatch build && hatch run test`
- Installed this package into [deadline-cloud-worker-agent](https://github.com/aws-deadline/deadline-cloud-worker-agent) and ran those integration tests (after making [some fixes](https://github.com/aws-deadline/deadline-cloud-worker-agent/pull/297)), verifying they succeed

### Was this change documented?
No

### Is this a breaking change?
Yes

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*