### PR TITLE
test: Set AWS_ENDPOINT_URL_DEADLINE on Worker

### DIFF
--- a/src/deadline_test_fixtures/deadline/worker.py
+++ b/src/deadline_test_fixtures/deadline/worker.py
@@ -57,6 +57,13 @@ def configure_worker_command(*, config: DeadlineWorkerConfiguration) -> str:  # 
             f"runuser -l {config.user} -s /bin/bash -c 'aws configure add-model --service-model file://{config.service_model_path}'"
         )
 
+    if os.environ.get("AWS_ENDPOINT_URL_DEADLINE"):
+        LOG.info(f"Using AWS_ENDPOINT_URL_DEADLINE: {os.environ.get('AWS_ENDPOINT_URL_DEADLINE')}")
+        cmds.insert(
+            0,
+            f"runuser -l {config.user} -s /bin/bash -c 'echo export AWS_ENDPOINT_URL_DEADLINE={os.environ.get('AWS_ENDPOINT_URL_DEADLINE')} >> ~/.bashrc'",
+        )
+
     return " && ".join(cmds)
 
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
In https://github.com/aws-deadline/deadline-cloud-test-fixtures/pull/96 we added functionality to specify and use `AWS_ENDPOINT_URL_DEADLINE`  to set a custom endpoint url. We do not currently set this env variable on the workers so that it can connect to designated endpoint

### What was the solution? (How)
Added the following to the worker configuration:

If the environment variable is specified, then add it to the Worker before installation so that it connects to the intended endpoint/farm location. 

### What is the impact of this change?
Enables AWS_ENDPOINT_URL_DEADLINE usage for the Worker Agent.

### How was this change tested?
Setting `AWS_ENDPOINT_URL_DEADLINE` and running `hatch run integ-test` i confirmed that the worker would connect to various endpoints.

### Was this change documented?
no

### Is this a breaking change?
no

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*