### PR TITLE
fix: restore support for deprecated WORKER_REGION env var

### DIFF
--- a/src/deadline_test_fixtures/fixtures.py
+++ b/src/deadline_test_fixtures/fixtures.py
@@ -145,7 +145,9 @@ def codeartifact() -> CodeArtifactRepositoryInfo:
 
 @pytest.fixture(scope="session")
 def region() -> str:
-    return os.getenv("REGION", os.getenv("AWS_DEFAULT_REGION", "us-west-2"))
+    return os.getenv(
+        "REGION", os.getenv("WORKER_REGION", os.getenv("AWS_DEFAULT_REGION", "us-west-2"))
+    )
 
 
 @pytest.fixture(scope="session")
@@ -402,8 +404,8 @@ def worker_config(
 
     # Deprecated environment variable
     if os.getenv("WORKER_REGION") is not None:
-        raise Exception(
-            "The environment variable WORKER_REGION is no longer supported. Please use REGION instead."
+        LOG.warning(
+            "DEPRECATED: The environment variable WORKER_REGION is no longer supported. Please use REGION instead."
         )
 
     # Prepare the Worker agent Python package


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

WORKER_REGION should have had a deprecation notice before throwing an exception when used. 

### What was the solution? (How)

Adding a temporary shim

### What is the impact of this change?

Having `WORKER_REGION` set in the environment wont cause an exception to be thrown. 

### How was this change tested?

### Was this change documented?

### Is this a breaking change?
no
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*