### PR TITLE
feat!: add windows support to worker fixture

### DIFF
--- a/src/deadline_test_fixtures/__init__.py
+++ b/src/deadline_test_fixtures/__init__.py
@@ -36,6 +36,7 @@ from .models import (
     PosixSessionUser,
     S3Object,
     ServiceModel,
+    OperatingSystem,
 )
 from ._version import __version__ as version  # noqa
 
@@ -60,6 +61,7 @@ __all__ = [
     "PosixSessionUser",
     "S3Object",
     "ServiceModel",
+    "OperatingSystem",
     "Queue",
     "QueueFleetAssociation",
     "TaskStatus",

--- a/test/unit/deadline/test_worker.py
+++ b/test/unit/deadline/test_worker.py
@@ -20,6 +20,7 @@ from deadline_test_fixtures import (
     DockerContainerWorker,
     EC2InstanceWorker,
     PipInstall,
+    OperatingSystem,
     S3Object,
 )
 
@@ -81,6 +82,7 @@ def worker_config(region: str) -> DeadlineWorkerConfiguration:
             ("/aws/models/deadline.json", "/tmp/deadline.json"),
         ],
         service_model_path="/path/to/service-2.json",
+        operating_system=OperatingSystem(name="AL2023"),
     )
 
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Add Windows support to the worker fixture.

### What was the solution? (How)
Add Windows support to the worker fixture.

### What is the impact of this change?
Adds Windows support to the worker fixture.

### How was this change tested?
Ran the e2e tests from the deadline-worker-agent repository and confirmed they passed:
```
hatch run windows-e2e-test
hatch run linux-e2e-test
```

Set `export WORKER_AGENT_WHL_PATH=/home/user/Projects/git/deadline-cloud-worker-agent/dist/deadline_cloud_worker_agent-0.27.0.post1.dev22-py3-none-any.whl`

Confirmed that the dev version was installed on the worker:
```
C:\Windows\system32> pip list
Package                     Version
--------------------------- ------------------
deadline-cloud-worker-agent 0.27.0.post1.dev22
```

Set `export AWS_ENDPOINT_URL_DEADLINE=<custom-endpoint>`

Confirmed that that it failed because the resource ids were not at that endpoint


### Was this change documented?
No

### Is this a breaking change?
Yes

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*