### PR TITLE
fix: check value of operating_system.name instead of operating_system

### DIFF
--- a/src/deadline_test_fixtures/fixtures.py
+++ b/src/deadline_test_fixtures/fixtures.py
@@ -420,7 +420,7 @@ def worker_config(
         ), f"Expected exactly one Worker agent whl path, but got {resolved_whl_paths} (from pattern {worker_agent_whl_path})"
         resolved_whl_path = resolved_whl_paths[0]
 
-        if operating_system == "AL2023":
+        if operating_system.name == "AL2023":
             dest_path = posixpath.join("/tmp", os.path.basename(resolved_whl_path))
         else:
             dest_path = posixpath.join(
@@ -445,7 +445,7 @@ def worker_config(
         with src_path.open(mode="w") as f:
             json.dump(service_model.model, f)
 
-        if operating_system == "AL2023":
+        if operating_system.name == "AL2023":
             dst_path = posixpath.join("/tmp", src_path.name)
         else:
             dst_path = posixpath.join("%USERPROFILE%\\AppData\\Local\\Temp", src_path.name)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

When running the tests I noticed that the fixtures were incorrectly detecting the OS type and trying to use Windows paths on my linux worker hosts. 

### What was the solution? (How)

Changed `operating_system == 'AL2023'` to `operating_system.name == 'AL2023'` in two places.

### What is the impact of this change?

The fixtures should work

### How was this change tested?

Ran tests with both Linux and Windows worker hosts.

### Was this change documented?

No

### Is this a breaking change?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*