### PR TITLE
chore(deps): Lower twine dependency to 5.0.* from 5.1.*

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -7,4 +7,4 @@ black == 24.4.*
 moto[cloudformation,s3] == 4.2.*
 mypy == 1.10.*
 ruff == 0.4.*
-twine == 5.1.*
+twine == 5.0.*


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Twine 5.1.* has been yanked due to https://github.com/pypa/twine/issues/1125. Leading to build errors 
### What was the solution? (How)
Downgrade it.
### What is the impact of this change?
Build should run again in this repo
### How was this change tested?
hatch build
### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*