### PR TITLE
fix!: delete workers from non-autoscaling fleets

### DIFF
--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -7,4 +7,4 @@ black == 24.4.*
 moto[cloudformation,s3] == 4.2.*
 mypy == 1.10.*
 ruff == 0.4.*
-twine == 5.0.*
+twine == 5.1.*

--- a/src/deadline_test_fixtures/deadline/resources.py
+++ b/src/deadline_test_fixtures/deadline/resources.py
@@ -103,6 +103,7 @@ class Queue:
 class Fleet:
     id: str
     farm: Farm
+    autoscaling: bool = True
 
     @staticmethod
     def create(

--- a/src/deadline_test_fixtures/fixtures.py
+++ b/src/deadline_test_fixtures/fixtures.py
@@ -454,7 +454,7 @@ def worker_config(
 
         yield DeadlineWorkerConfiguration(
             farm_id=deadline_resources.farm.id,
-            fleet_id=deadline_resources.fleet.id,
+            fleet=deadline_resources.fleet,
             region=region,
             user=os.getenv("WORKER_POSIX_USER", "deadline-worker"),
             group=os.getenv("WORKER_POSIX_SHARED_GROUP", "shared-group"),
@@ -514,10 +514,12 @@ def worker(
         ec2_client = boto3.client("ec2")
         s3_client = boto3.client("s3")
         ssm_client = boto3.client("ssm")
+        deadline_client = boto3.client("deadline")
 
         worker = EC2InstanceWorker(
             ec2_client=ec2_client,
             s3_client=s3_client,
+            deadline_client=deadline_client,
             bootstrap_bucket_name=bootstrap_resources.bootstrap_bucket_name,
             ssm_client=ssm_client,
             override_ami_id=ami_id,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
non-autoscaling fleets workers are not deleted automatically from fleets. This causes errors when tests are run more than the amount of workers a fleet is allowed to launch.

### What was the solution? (How)
* Add autoscaling attribute to Fleet object.
* When terminating an instances, if it is a non-autoscaling fleet, wait for the worker to be in a STOPPED state and then delete the worker from the fleet.

### What is the impact of this change?
Allow the tests to run more than twice.

### How was this change tested?
Tested using the Worker Agent tests.

### Was this change documented?
No

### Is this a breaking change?
Yes, changes the behaviour of how workers are stopped. We now  pass a fleet object to the worker configuration instead of an id.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*