### PR TITLE
chore(deps): update moto to 5.0.* and ruff to 0.5.*

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -8,7 +8,7 @@ sync = "pip install -r requirements-testing.txt"
 test = "pytest --cov-config pyproject.toml {args:test}"
 typing = "mypy {args:src test}"
 style = [
-  "ruff {args:.}",
+  "ruff check {args:.}",
   "black --check --diff {args:.}",
 ]
 fmt = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,12 +101,14 @@ module = "moto"
 ignore_missing_imports = true
 
 [tool.ruff]
+line-length = 100
+
+[tool.ruff.lint]
 ignore = [
   "E501",
 ]
-line-length = 100
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = [
   "deadline_test_fixtures"
 ]

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -4,7 +4,7 @@ pytest-cov == 5.0.*
 pytest-timeout == 2.3.*
 pytest-xdist == 3.6.*
 black == 24.4.*
-moto[cloudformation,s3] == 4.2.*
+moto[cloudformation,s3] == 5.0.*
 mypy == 1.10.*
-ruff == 0.4.*
+ruff == 0.5.*
 twine == 5.1.*

--- a/test/unit/cloudformation/test_cfn.py
+++ b/test/unit/cloudformation/test_cfn.py
@@ -6,7 +6,7 @@ import boto3
 import pytest
 from botocore.client import BaseClient
 from botocore.exceptions import ClientError
-from moto import mock_cloudformation
+from moto import mock_aws
 
 from deadline_test_fixtures.cloudformation.cfn import (
     CfnResource,
@@ -35,7 +35,7 @@ class TestCfnStack:
 
     @pytest.fixture
     def cfn_client(self) -> Generator[BaseClient, None, None]:
-        with mock_cloudformation():
+        with mock_aws():
             yield boto3.client("cloudformation")
 
     class TestDeploy:

--- a/test/unit/deadline/test_worker.py
+++ b/test/unit/deadline/test_worker.py
@@ -10,7 +10,7 @@ from unittest.mock import ANY, MagicMock, call, mock_open, patch
 import boto3
 import pytest
 from botocore.exceptions import ClientError
-from moto import mock_ec2, mock_iam, mock_s3, mock_ssm
+from moto import mock_aws
 
 from deadline_test_fixtures.deadline import worker as mod
 from deadline_test_fixtures import (
@@ -29,7 +29,7 @@ from deadline_test_fixtures import (
 
 @pytest.fixture(autouse=True)
 def moto_mocks() -> Generator[None, None, None]:
-    with mock_ec2(), mock_iam(), mock_s3(), mock_ssm():
+    with mock_aws():
         yield
 
 

--- a/test/unit/test_job_attachment_manager.py
+++ b/test/unit/test_job_attachment_manager.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 import boto3
 import pytest
 from botocore.exceptions import ClientError, WaiterError
-from moto import mock_s3
+from moto import mock_aws
 
 from deadline_test_fixtures import job_attachment_manager as jam_module
 from deadline_test_fixtures import DeadlineClient, JobAttachmentManager
@@ -26,7 +26,7 @@ class TestJobAttachmentManager:
     def job_attachment_manager(
         self,
     ) -> Generator[JobAttachmentManager, None, None]:
-        with mock_s3():
+        with mock_aws():
             yield JobAttachmentManager(
                 s3_client=boto3.client("s3"),
                 deadline_client=DeadlineClient(MagicMock()),


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

dependabot was unable to update moto or ruff due to code changes

### What was the solution? (How)

replace mock_<service> with mock_aws, and update to `ruff check <.>`

### What is the impact of this change?

newer deps!

### How was this change tested?

```
hatch run lint
hatch run test
```

### Was this change documented?

N/A

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*