### PR TITLE
fix: BYO Deadline now looks specifically for resource env vars.

### DIFF
--- a/src/deadline_test_fixtures/fixtures.py
+++ b/src/deadline_test_fixtures/fixtures.py
@@ -281,21 +281,16 @@ def deadline_resources(
     """
     if os.getenv("BYO_DEADLINE", "false").lower() == "true":
         kwargs: dict[str, Any] = {}
+        resource_env_vars: list[str] = [
+            "FARM_ID",
+            "FLEET_ID",
+            "QUEUE_ID",
+        ]
 
-        all_fields = fields(DeadlineResources)
-        for f in all_fields:
-            env_var = f.name.upper()
+        for env_var in resource_env_vars:
             if env_var in os.environ:
-                kwargs[f.name] = os.environ[env_var]
+                kwargs[env_var.lower()] = os.environ[env_var]
 
-        required_fields = [f for f in all_fields if (MISSING == f.default == f.default_factory)]
-        assert all([rf.name in kwargs for rf in required_fields]), (
-            "Not all Deadline resources have been fulfilled via environment variables. Expected "
-            + f"values for {[f.name.upper() for f in required_fields]}, but got {kwargs}"
-        )
-        LOG.info(
-            f"All Deadline resources have been fulfilled via environment variables. Using {kwargs}"
-        )
         yield DeadlineResources(**kwargs)
     else:
         LOG.info("Deploying Deadline resources")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The fields of DeadlineResources don't match the kwargs in it's constructor. Either, you don't provide `FARM`, `FLEET` and `QUEUE` and the required field validation fails OR you do provide them and the constructor for  DeadlineResources fails because it doesn't recognize a keyword named `farm`.

### What was the solution? (How)
We're going to leave validation of required fields to the dataclass itself. Pull the specific env vars we want out for specifying the resources. 

### What is the impact of this change?
Unblocks BYO Deadline testing workflows. 

### How was this change tested?
I have an existing Farm, Fleet and Queue. I was able to use these fixtures to run tests against them. My account is limited to on 2 Farms (which I already have) if this didn't work I would have gotten errors making a new Farm.

### Was this change documented?
No.

### Is this a breaking change?
No.
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*