### PR TITLE
fix: Add default max_retries to Job.wait_until_complete to avoid infinite waiting

### DIFF
--- a/src/deadline_test_fixtures/deadline/resources.py
+++ b/src/deadline_test_fixtures/deadline/resources.py
@@ -6,7 +6,7 @@ import json
 import logging
 from dataclasses import asdict, dataclass, fields
 from enum import Enum
-from typing import Any, Callable, Literal, TYPE_CHECKING
+from typing import Any, Callable, Literal, TYPE_CHECKING, Optional
 
 from botocore.client import BaseClient
 
@@ -579,7 +579,7 @@ class Job:
         *,
         client: DeadlineClient,
         wait_interval_sec: int = 10,
-        max_retries: int | None = None,
+        max_retries: Optional[int] = 20,
     ) -> None:
         """
         Waits until the job is complete.
@@ -587,7 +587,7 @@ class Job:
 
         Args:
             wait_interval_sec (int, optional): Interval between waits in seconds. Defaults to 5.
-            max_retries (int, optional): Maximum retry count. Defaults to None.
+            max_retries (int, optional): Maximum retry count. Defaults to 20.
         """
 
         def _is_job_complete():


### PR DESCRIPTION


### What was the problem/requirement? (What/Why)
Job.wait_until_complete() has a default `max_retries` of infinite retries, which is problematic if something unforeseen happens and the tests that use the function will just retry forever.

We should add a default for the function so that will not happen.
### What was the solution? (How)
Add a default to the `wait_until_complete()` function for its `max_retries` parameter, so that the default behaviour would be to retry up to the default number of times, waiting for the job to complete.
### What is the impact of this change?
 More robust tests, and less possibility of an infinite loop happening in the off chance,.
### How was this change tested?
`hatch build` `hatch run fmt` `hatch run test`
### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*