### PR TITLE
feat: Allow EC2InstanceWorker.stop() to not wait for worker to be stopped

### DIFF
--- a/src/deadline_test_fixtures/deadline/worker.py
+++ b/src/deadline_test_fixtures/deadline/worker.py
@@ -177,13 +177,13 @@ class EC2InstanceWorker(DeadlineWorker):
         self._launch_instance(s3_files=s3_files)
         self._start_worker_agent()
 
-    def stop(self) -> None:
+    def stop(self, wait_until_stopped: Optional[bool] = True) -> None:
         LOG.info(f"Terminating EC2 instance {self.instance_id}")
         self.ec2_client.terminate_instances(InstanceIds=[self.instance_id])
 
         self.instance_id = None
 
-        if not self.configuration.fleet.autoscaling:
+        if wait_until_stopped and not self.configuration.fleet.autoscaling:
             try:
                 self.wait_until_stopped()
             except TimeoutError:


### PR DESCRIPTION


### What was the problem/requirement? (What/Why)

In our tests, we will have tests that wish to verify that worker is in a `STOPPING` status, without waiting for the worker to be `STOPPED`.
### What was the solution? (How)
Add an option for the `Worker.stop()` function to not wait for worker to be `STOPPED`, so that in tests we can verify that a worker is `STOPPING`
### What is the impact of this change?
More flexibility in test code
### How was this change tested?
`hatch run fmt`, `hatch build`
### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*