### PR TITLE
fix: remove runas from job attachment fixture

### DIFF
--- a/src/deadline_test_fixtures/deadline/resources.py
+++ b/src/deadline_test_fixtures/deadline/resources.py
@@ -60,7 +60,7 @@ class Queue:
         client: DeadlineClient,
         display_name: str,
         farm: Farm,
-        job_run_as_user: JobRunAsUser,
+        job_run_as_user: JobRunAsUser | None = None,
         role_arn: str | None = None,
         job_attachments: JobAttachmentSettings | None = None,
         raw_kwargs: dict | None = None,
@@ -73,7 +73,7 @@ class Queue:
                 "jobAttachmentSettings": (
                     job_attachments.as_queue_settings() if job_attachments else None
                 ),
-                "jobRunAsUser": asdict(job_run_as_user),
+                "jobRunAsUser": asdict(job_run_as_user) if job_run_as_user else None,
                 **(raw_kwargs or {}),
             }
         )

--- a/src/deadline_test_fixtures/job_attachment_manager.py
+++ b/src/deadline_test_fixtures/job_attachment_manager.py
@@ -14,9 +14,6 @@ from .deadline import (
 
 from .models import (
     JobAttachmentSettings,
-    JobRunAsUser,
-    PosixSessionUser,
-    WindowsSessionUser,
 )
 from uuid import uuid4
 
@@ -52,11 +49,6 @@ class JobAttachmentManager:
                 client=self.deadline_client,
                 display_name="job_attachments_test_queue",
                 farm=Farm(self.farm_id),
-                job_run_as_user=JobRunAsUser(
-                    posix=PosixSessionUser("", ""),
-                    runAs="WORKER_AGENT_USER",
-                    windows=WindowsSessionUser("", ""),
-                ),
                 job_attachments=JobAttachmentSettings(
                     bucket_name=self.bucket_name, root_prefix=self.bucket_root_prefix
                 ),
@@ -65,11 +57,6 @@ class JobAttachmentManager:
                 client=self.deadline_client,
                 display_name="job_attachments_test_no_settings_queue",
                 farm=Farm(self.farm_id),
-                job_run_as_user=JobRunAsUser(
-                    posix=PosixSessionUser("", ""),
-                    runAs="WORKER_AGENT_USER",
-                    windows=WindowsSessionUser("", ""),
-                ),
             )
 
         except (ClientError, WaiterError):


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Deadline cloud integration tests are failing due to a parameter validation on the runas user password arn for a Windows user.

```
/root/.local/share/hatch/env/virtual/deadline/3D9T-Jhn/integ/lib/python3.9/site-packages/deadline_test_fixtures/fixtures.py:623: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/root/.local/share/hatch/env/virtual/deadline/3D9T-Jhn/integ/lib/python3.9/site-packages/deadline_test_fixtures/job_attachment_manager.py:51: in deploy_resources
    self·[39;49;00m.queue = Queue.create(·[39;49;00m
/root/.local/share/hatch/env/virtual/deadline/3D9T-Jhn/integ/lib/python3.9/site-packages/deadline_test_fixtures/deadline/resources.py:81: in create
    response = call_api(·[39;49;00m
/root/.local/share/hatch/env/virtual/deadline/3D9T-Jhn/integ/lib/python3.9/site-packages/deadline_test_fixtures/util.py:38: in call_api
    response = fn()·[39;49;00m
/root/.local/share/hatch/env/virtual/deadline/3D9T-Jhn/integ/lib/python3.9/site-packages/deadline_test_fixtures/deadline/resources.py:83: in <lambda>
    fn=lambda·[39;49;00m: client.create_queue(**kwargs),·[39;49;00m
/root/.local/share/hatch/env/virtual/deadline/3D9T-Jhn/integ/lib/python3.9/site-packages/deadline_test_fixtures/deadline/client.py:82: in create_queue
    return·[39;49;00m self·[39;49;00m._real_client.create_queue(*args, **kwargs)·[39;49;00m
/root/.local/share/hatch/env/virtual/deadline/3D9T-Jhn/integ/lib/python3.9/site-packages/botocore/client.py:565: in _api_call
    return·[39;49;00m self·[39;49;00m._make_api_call(operation_name, kwargs)·[39;49;00m
/root/.local/share/hatch/env/virtual/deadline/3D9T-Jhn/integ/lib/python3.9/site-packages/botocore/client.py:974: in _make_api_call
    request_dict = self·[39;49;00m._convert_to_request_dict(·[39;49;00m
/root/.local/share/hatch/env/virtual/deadline/3D9T-Jhn/integ/lib/python3.9/site-packages/botocore/client.py:1041: in _convert_to_request_dict
    request_dict = self·[39;49;00m._serializer.serialize_to_request(·[39;49;00m
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
self = <botocore.validate.ParamValidationDecorator object at 0x7f68b6fdd6d0>
parameters = {'clientToken': '9bb987ef-d252-42ec-b780-7e7ec9c21ab1', 'displayName': 'job_attachments_test_queue', 'farmId': 'farm-c...run/fe78139b-94c4-41db-9239-b830b3143a07', 's3BucketName': 'deadline-test-fixtures-job-attachments-938076848303'}, ...}
operation_model = OperationModel(name=CreateQueue)
    def·[39;49;00m serialize_to_request·[39;49;00m(self·[39;49;00m, parameters, operation_model):·[39;49;00m
        input_shape = operation_model.input_shape·[39;49;00m
        if·[39;49;00m input_shape is·[39;49;00m not·[39;49;00m None·[39;49;00m:·[39;49;00m
            report = self·[39;49;00m._param_validator.validate(·[39;49;00m
                parameters, operation_model.input_shape·[39;49;00m
            )·[39;49;00m
            if·[39;49;00m report.has_errors():·[39;49;00m
>               raise·[39;49;00m ParamValidationError(report=report.generate_report())·[39;49;00m
E               botocore.exceptions.ParamValidationError: Parameter validation failed:
E               Invalid length for parameter jobRunAsUser.windows.passwordArn, value: 0, valid min length: 20
/root/.local/share/hatch/env/virtual/deadline/3D9T-Jhn/integ/lib/python3.9/site-packages/botocore/validate.py:381: ParamValidationError
```

### What was the solution? (How)
The job attachment integ tests don't require a user to be specified, so remove that field from the queues it creates.

### What is the impact of this change?
Deadline cloud integ tests should pass

### How was this change tested?
Installed into my deadline cloud workspace and ran the integ tests. I ensured they passed.

### Was this change documented?
N/A

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*