### PR TITLE
fix: add missing comma to ssm command

### DIFF
--- a/src/deadline_test_fixtures/deadline/worker.py
+++ b/src/deadline_test_fixtures/deadline/worker.py
@@ -723,8 +723,8 @@ class PosixInstanceWorker(EC2InstanceWorker):
         cmd_result = self.send_command(
             " && ".join(
                 [
-                    f"t=0 && while [ $t -le 10 ] && ! (test -f {worker_state_filename}); do sleep $t; t=$[$t+1]; done"
-                    f"cat {worker_state_filename} | jq -r '.worker_id'"
+                    f"t=0 && while [ $t -le 10 ] && ! (test -f {worker_state_filename}); do sleep $t; t=$[$t+1]; done",
+                    f"cat {worker_state_filename} | jq -r '.worker_id'",
                 ]
             )
         )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We were missing a comma in an ssm command list. Unfortunately in Python having two string on a separate line in a list is valid syntax and it concats the two lines together.

### What was the solution? (How)
Add the missing commas!

### What is the impact of this change?
Integ tests pass.

### How was this change tested?
I added the new build to the `requirements-test.txt` in the deadline worker agent repo. I then made sure the change was in the hatch environment. I ran the linux e2e tests and made sure they passed.

### Was this change documented?
N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*