### PR TITLE
feat: linux ec2-based tests test installer-based user creation

### DIFF
--- a/src/deadline_test_fixtures/deadline/worker.py
+++ b/src/deadline_test_fixtures/deadline/worker.py
@@ -619,7 +619,7 @@ class PosixInstanceWorker(EC2InstanceWorker):
 
         cmds = [
             "source /opt/deadline/worker/bin/activate",
-            "AWS_DEFAULT_REGION={self.configuration.region}",
+            f"AWS_DEFAULT_REGION={self.configuration.region}",
             config.worker_agent_install.install_command_for_linux,
             *(config.pre_install_commands or []),
             # fmt: off

--- a/test/unit/deadline/test_worker.py
+++ b/test/unit/deadline/test_worker.py
@@ -288,7 +288,7 @@ class TestPosixInstanceWorker:
             send_command_spy.assert_called_once_with(
                 InstanceIds=[worker.instance_id],
                 DocumentName="AWS-RunShellScript",
-                Parameters={"commands": [cmd]},
+                Parameters={"commands": ["set -eou pipefail; " + cmd]},
             )
 
         def test_retries_when_instance_not_ready(self, worker: PosixInstanceWorker) -> None:
@@ -323,7 +323,7 @@ class TestPosixInstanceWorker:
                     call(
                         InstanceIds=[worker.instance_id],
                         DocumentName="AWS-RunShellScript",
-                        Parameters={"commands": [cmd]},
+                        Parameters={"commands": ["set -eou pipefail; " + cmd]},
                     )
                 ]
                 * 2
@@ -351,7 +351,7 @@ class TestPosixInstanceWorker:
             mock_send_command.assert_called_once_with(
                 InstanceIds=[worker.instance_id],
                 DocumentName="AWS-RunShellScript",
-                Parameters={"commands": [cmd]},
+                Parameters={"commands": ["set -eou pipefail; " + cmd]},
             )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)

The linux ec2-based tests are currently structured to create the worker-agent user during instance startup using ec2-userdata scripting. The worker agent installer contains code that will create the agent-user if it does not exist. The current test setup prevents writing tests that test that functionality

### What was the solution? (How)

Refactor the scripting that is materialized in the PosixInstanceWorker. Now, user-creation-wise the ec2-userdata only creates the job users and their groups. The 'worker configuration' scripting is now responsible for letting the install script create the worker agent user, and adding it to the required groups & sudoers rules.

### What is the impact of this change?

Increased confidence that the deadline cloud worker agent's installer script on Linux correctly creates the agent-user if it needs to.

### How was this change tested?

1. [Followed the instructions](https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/mainline/DEVELOPMENT.md#running-worker-agent-e2e-tests) for running the e2e tests for the Deadline Cloud worker agent.
2. To make the e2e tests use the Before running the tests:
    1. Modified the agent's `requirements-testing.txt` to point at my built whl file for the test-fixtures. ( `deadline-cloud-test-fixtures @ file:///home/<user>/deadline-cloud-test-fixtures/dist/deadline_cloud_test_fixtures-0.0.post98+g6d4023d.d20240813-py3-none-any.whl`)
    2. Force pip installed the requirements-testing.txt into my testing venv.
    3. Set the `WORKER_AGENT_WHL_PATH` env var to point to my locally built agent whl file.
    4. Pruned all hatch environments, and then ran the e2e tests as prescribed.

I then checked command history in Systems Manager to ensure that the expected RunCommands were run (as a verification that my test fixtures changes were being tested).

All Linux tests pass:

```
============================================================================= slowest 5 durations =============================================================================
174.11s setup    test/e2e/linux/test_credential_handling.py::test_access_worker_credential_file_from_job[linux]
42.03s call     test/e2e/linux/test_job_submissions.py::TestJobSubmission::test_success[linux]
25.38s call     test/e2e/linux/test_job_submissions.py::TestJobSubmission::test_job_run_as_user[linux]
10.30s call     test/e2e/linux/test_credential_handling.py::test_access_worker_credential_file_from_job[linux]
5.71s teardown test/e2e/linux/test_job_submissions.py::TestJobSubmission::test_job_run_as_user[linux]
================================================================== 4 passed, 1 warning in 263.58s (0:04:23)
```

### Was this change documented?

There is no documentation to update.

### Is this a breaking change?

It should not be.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*