### PR TITLE
fix: increase number of retries for SSM send_command to 60

### DIFF
--- a/src/deadline_test_fixtures/deadline/worker.py
+++ b/src/deadline_test_fixtures/deadline/worker.py
@@ -253,7 +253,7 @@ class EC2InstanceWorker(DeadlineWorker):
         #
         # If we send an SSM command then we will get an InvalidInstanceId error
         # if the instance isn't in that state.
-        NUM_RETRIES = 30
+        NUM_RETRIES = 60
         SLEEP_INTERVAL_S = 10
         for i in range(0, NUM_RETRIES):
             LOG.info(f"Sending SSM command to instance {self.instance_id}")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Windows workers boot up takes longer than Linux workers, so the current total retry time to verify that we can send an SSM command, which is 5 minutes is not sufficient, in rare cases.
### What was the solution? (How)
Increase the timeout for sending an SSM command on a launched EC2 instance.

### What is the impact of this change?
More slack in waiting for the windows worker to be booted, less flakiness
### How was this change tested?

hatch run fmt

Pulled the worker agent package and installed this version of test-fixtures, confirmed that the timeout was increase and it successfully waited for the worker to start.

### Was this change documented?
no
### Is this a breaking change?
no
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*