### PR TITLE
fix: append export AWS_ENDPOINT_URL_DEADLINE at end of worker SSM commands

### DIFF
--- a/src/deadline_test_fixtures/deadline/worker.py
+++ b/src/deadline_test_fixtures/deadline/worker.py
@@ -485,8 +485,7 @@ class WindowsInstanceWorker(EC2InstanceWorker):
             LOG.info(
                 f"Using AWS_ENDPOINT_URL_DEADLINE: {os.environ.get('AWS_ENDPOINT_URL_DEADLINE')}"
             )
-            cmds.insert(
-                0,
+            cmds.append(
                 f"[System.Environment]::SetEnvironmentVariable('AWS_ENDPOINT_URL_DEADLINE', '{os.environ.get('AWS_ENDPOINT_URL_DEADLINE')}', [System.EnvironmentVariableTarget]::Machine); "
                 "$env:AWS_ENDPOINT_URL_DEADLINE = [System.Environment]::GetEnvironmentVariable('AWS_ENDPOINT_URL_DEADLINE','Machine')",
             )
@@ -670,8 +669,7 @@ class PosixInstanceWorker(EC2InstanceWorker):
             LOG.info(
                 f"Using AWS_ENDPOINT_URL_DEADLINE: {os.environ.get('AWS_ENDPOINT_URL_DEADLINE')}"
             )
-            cmds.insert(
-                0,
+            cmds.append(
                 f"runuser -l {config.agent_user} -s /bin/bash -c 'echo export AWS_ENDPOINT_URL_DEADLINE={os.environ.get('AWS_ENDPOINT_URL_DEADLINE')} >> ~/.bashrc'",
             )
 


### PR DESCRIPTION

### What was the problem/requirement? (What/Why)
When we spin up multiple workers, the 2nd worker and so forth always fails since in the command to install the worker agent, we `runuser` as a deadline-worker user that has not been created yet, trying to export an env variable.
### What was the solution? (How)
Move the `runuser` command to the end of the commands, so the user is actually created during the worker agent install.
### What is the impact of this change?
The failing worker-agent tests that use a separate worker from the main session worker should pass again 
### How was this change tested?
Built into worker-agent repo, and used `hatch run cross-os-e2e-test` to verify on Linux that it works
### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*