### PR TITLE
fix: start windows worker service depending on the worker configuration

### DIFF
--- a/src/deadline_test_fixtures/deadline/worker.py
+++ b/src/deadline_test_fixtures/deadline/worker.py
@@ -536,7 +536,7 @@ class WindowsInstanceBuildWorker(WindowsInstanceWorkerBase):
                 + f"--region {config.region} "
                 + f"--user {config.agent_user} "
                 + f"{'--allow-shutdown ' if config.allow_shutdown else ''}"
-                + "--start"
+                + f"{'--start ' if config.start_service else ''}"
             ),
             # fmt: on
         ]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The Posix deadline-worker service started depending on whether the worker configuration had `start_service` set to True or False, but the WIndows service did not.
### What was the solution? (How)
Also make the WIndows service dependent on the worker configuration in specifying whether the service should start after the install.
### What is the impact of this change?
Better and more consistent testing experience across Windows and Posix
### How was this change tested?
hatch run fmt, hatch build
### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*