### PR TITLE
fix: start service after running the installer instead of during

### DIFF
--- a/src/deadline_test_fixtures/deadline/worker.py
+++ b/src/deadline_test_fixtures/deadline/worker.py
@@ -536,7 +536,6 @@ class WindowsInstanceBuildWorker(WindowsInstanceWorkerBase):
                 + f"--region {config.region} "
                 + f"--user {config.agent_user} "
                 + f"{'--allow-shutdown ' if config.allow_shutdown else ''}"
-                + f"{'--start ' if config.start_service else ''}"
             ),
             # fmt: on
         ]
@@ -545,6 +544,9 @@ class WindowsInstanceBuildWorker(WindowsInstanceWorkerBase):
             cmds.append(
                 f"Copy-Item -Path ~\\.aws\\* -Destination C:\\Users\\{config.agent_user}\\.aws\\models -Recurse; "
             )
+
+        if config.start_service:
+            cmds.append('Start-Service -Name "DeadlineWorker"')
 
         return "; ".join(cmds)
 
@@ -746,7 +748,6 @@ class PosixInstanceBuildWorker(PosixInstanceWorkerBase):
                 + f"--group {config.job_user_group} "
                 + f"{'--allow-shutdown ' if config.allow_shutdown else ''}"
                 + f"{'--no-install-service ' if config.no_install_service else ''}"
-                + f"{'--start ' if config.start_service else ''}"
             ),
             # fmt: on
             f"runuser --login {self.configuration.agent_user} --command 'echo \"source /opt/deadline/worker/bin/activate\" >> $HOME/.bashrc'",
@@ -766,6 +767,9 @@ class PosixInstanceBuildWorker(PosixInstanceWorkerBase):
         )
 
         cmds.append(self.configure_agent_user_environment(config))
+
+        if config.start_service:
+            cmds.append("systemctl start deadline-worker")
 
         return " && ".join(cmds)
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
There is an issue with some of the Worker Agent E2E tests in which the task fails with worker agent logs indicating some permission issues. This caused failures with some of the E2E tests.

The issue is possibly that the agent user and the job user are not in a shared posix group. This may be because the agent user isn't in the correct job-user group, due to us starting the worker agent service alongside the installation of the worker agent.

### What was the solution? (How)
Start the worker agent service only after the installation of worker, which may fix the issue with the tasks seemingly randomly failing.

The agent user and environment will be setup before the worker agent starts, after this change.

### What is the impact of this change?
The WA E2E tests should no longer be as flaky.
### How was this change tested?
Tested with this build in the Worker Agent package, and ran 
```
# Linux
source .e2e_linux_infra.sh
hatch run linux-e2e-test
hatch run cross-os-e2e-test

# Windows
source .e2e_windows_infra.sh
hatch run windows-e2e-test
hatch run cross-os-e2e-test
```

The tests passed, at least against my dev setup.
### Was this change documented?
No
### Is this a breaking change?
no
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*