### PR TITLE
fix: silent progress ui

### DIFF
--- a/src/deadline_test_fixtures/deadline/worker.py
+++ b/src/deadline_test_fixtures/deadline/worker.py
@@ -572,6 +572,7 @@ class WindowsInstanceBuildWorker(WindowsInstanceWorkerBase):
         configure_job_users = "\n".join(job_users_cmds)
 
         userdata = f"""<powershell>
+$ProgressPreference = 'SilentlyContinue'
 Invoke-WebRequest -Uri "https://www.python.org/ftp/python/3.11.9/python-3.11.9-amd64.exe" -OutFile "C:\python-3.11.9-amd64.exe"
 $installerHash=(Get-FileHash "C:\python-3.11.9-amd64.exe" -Algorithm "MD5")
 $expectedHash="e8dcd502e34932eebcaf1be056d5cbcd"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Invoke-WebRequest is taking a long time to download files.

### What was the solution? (How)
Apparently this is due to the progress reporter UI. Setting the progress preference to silent improves download time by 2-3 minutes

### What is the impact of this change?
Improve startup time of ec2 instance and ssm

### How was this change tested?
Tested using a local checkout of the deadline-worker-agent e2e tests

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*