### PR TITLE
fix: add WaiterConfig to ssm command waiter

### DIFF
--- a/src/deadline_test_fixtures/deadline/worker.py
+++ b/src/deadline_test_fixtures/deadline/worker.py
@@ -281,6 +281,7 @@ class EC2InstanceWorker(DeadlineWorker):
             ssm_waiter.wait(
                 InstanceId=self.instance_id,
                 CommandId=command_id,
+                WaiterConfig={"Delay": 5, "MaxAttempts": 30},
             )
         except botocore.exceptions.WaiterError:  # pragma: no cover
             # Swallow exception, we're going to check the result anyway

--- a/src/deadline_test_fixtures/models.py
+++ b/src/deadline_test_fixtures/models.py
@@ -228,7 +228,7 @@ class PipInstall:  # pragma: no cover
             )
 
         if self.upgrade_pip:
-            cmds.append("pip install --upgrade pip")
+            cmds.append("python -m pip install --upgrade pip")
 
         cmds.append(
             " ".join(


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
1. Worker installation/configuration is taking more than 100 seconds which is the default timeout for the waiter. This results in a -1 exit code being returned despite the command completing successfully.

2. The pip upgrade command for windows is not completing successfully.

### What was the solution? (How)
1. Add a WaiterConfig to increase the timeout
2. Use `python -m` to upgrade pip

### What is the impact of this change?
Resolves errors that were happening during the worker configuration and installation

### How was this change tested?
Tested using the Worker E2E tests
```
hatch run e2e-test
```

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*