### PR TITLE
feat!: increase retries for log contains utils 

### DIFF
--- a/src/deadline_test_fixtures/deadline/resources.py
+++ b/src/deadline_test_fixtures/deadline/resources.py
@@ -736,7 +736,7 @@ class Job:
         logs_client: BaseClient,
         expected_pattern: re.Pattern | str,
         assert_fail_msg: str = "Expected message not found in session log",
-        retries: int = 4,
+        retries: int = 6,
         backoff_factor: timedelta = timedelta(milliseconds=300),
     ) -> None:
         """
@@ -1171,7 +1171,7 @@ class Session:
         logs_client: BaseClient,
         expected_pattern: re.Pattern | str,
         assert_fail_msg: str = "Expected message not found in session log",
-        retries: int = 4,
+        retries: int = 6,
         backoff_factor: timedelta = timedelta(milliseconds=300),
     ) -> None:
         """

--- a/test/unit/deadline/test_resources.py
+++ b/test/unit/deadline/test_resources.py
@@ -1123,7 +1123,7 @@ class TestJob:
             expected_pattern=expected_pattern,
             assert_fail_msg="Expected message not found in session log",
             backoff_factor=datetime.timedelta(milliseconds=300),
-            retries=4,
+            retries=6,
         )
         mock_list_steps.assert_called_once_with(deadline_client=deadline_client)
         step.list_tasks.assert_called_once_with(deadline_client=deadline_client)
@@ -1629,7 +1629,7 @@ class TestSession:
             f"{assert_fail_msg or 'Expected message not found in session log'}."
             f" Logs are in CloudWatch log group: {session_log_group_name}"
         )
-        expected_retries = retries if retries is not None else 4
+        expected_retries = retries if retries is not None else 6
         expected_backoff_factor = (
             backoff_factor if backoff_factor is not None else datetime.timedelta(milliseconds=300)
         )


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
There have been some flaky tests in worker agent E2E tests lately, in which cloudwatch logs take longer than expected to stream after a job is done. This has caused the tests to fail flakily, and is the main reason the canaries fail.

We should make sure the tests themselves are robust and don't fail due to expected delays.
### What was the solution? (How)
Increase retries to the number of times we try to get the job logs in the utils.
### What is the impact of this change?
Less flaky worker agent e2e tests.
### How was this change tested?
`hatch run fmt`
`hatch run lint`
`hatch build`

Will monitor after this package is released for flakiness of the worker agent tests.
### Was this change documented?
No
### Is this a breaking change?
Yes

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*