### PR TITLE
feat: allow worker config tests to disallow instance profile

### DIFF
--- a/src/deadline_test_fixtures/deadline/worker.py
+++ b/src/deadline_test_fixtures/deadline/worker.py
@@ -93,6 +93,7 @@ class DeadlineWorkerConfiguration:
     no_install_service: bool = False
     service_model_path: str | None = None
     no_local_session_logs: str | None = None
+    disallow_instance_profile: str | None = None
 
     """Mapping of files to copy from host environment to worker environment"""
     file_mappings: list[tuple[str, str]] | None = None
@@ -544,6 +545,7 @@ class WindowsInstanceBuildWorker(WindowsInstanceWorkerBase):
                 + f"--region {config.region} "
                 + f"--user {config.agent_user} "
                 + f"{'--allow-shutdown ' if config.allow_shutdown else ''}"
+                + f"{'--disallow-instance-profile ' if config.disallow_instance_profile else ''}"
             ),
             # fmt: on
         ]
@@ -767,6 +769,7 @@ class PosixInstanceBuildWorker(PosixInstanceWorkerBase):
                 + f"--group {config.job_user_group} "
                 + f"{'--allow-shutdown ' if config.allow_shutdown else ''}"
                 + f"{'--no-install-service ' if config.no_install_service else ''}"
+                + f"{'--disallow-instance-profile ' if config.disallow_instance_profile else ''}"
             ),
             # fmt: on
             f"runuser --login {self.configuration.agent_user} --command 'echo \"source /opt/deadline/worker/bin/activate\" >> $HOME/.bashrc'",


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
For some of the worker agent e2e tests, we would like to verify the worker agent behaviour when we disallow instance profile (one of the worker install options)

### What was the solution? (How)
Allow this option in the worker test fixture.
### What is the impact of this change?
Allows the worker e2e tests to verify worker agent behaviour when we disallow instance profiles.
### How was this change tested?
`hatch run fmt && hatch run lint && hatch run test && hatch build`

Verify the option exists in the installer.
### Was this change documented?
No
### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*