### PR TITLE
fix: incorrect filesystem paths to files fetched from S3 by userdata

### DIFF
--- a/src/deadline_test_fixtures/deadline/worker.py
+++ b/src/deadline_test_fixtures/deadline/worker.py
@@ -453,7 +453,7 @@ class WindowsInstanceWorkerBase(EC2InstanceWorker):
         This cannot assume that the agent user exists.
         """
 
-        cmds = []
+        cmds = ["$ErrorActionPreference = 'Stop'"]
 
         if config.service_model_path:
             cmds.append(

--- a/src/deadline_test_fixtures/fixtures.py
+++ b/src/deadline_test_fixtures/fixtures.py
@@ -448,7 +448,8 @@ def worker_config(
             dest_path = posixpath.join("/tmp", os.path.basename(resolved_whl_path))
         else:
             dest_path = posixpath.join(
-                "$env:USERPROFILE\\AppData\\Local\\Temp", os.path.basename(resolved_whl_path)
+                "C:\\Windows\\System32\\Config\\systemprofile\\AppData\\Local\\Temp",
+                os.path.basename(resolved_whl_path),
             )
         file_mappings = [(resolved_whl_path, dest_path)]
 
@@ -472,7 +473,9 @@ def worker_config(
         if operating_system.name == "AL2023":
             dst_path = posixpath.join("/tmp", src_path.name)
         else:
-            dst_path = posixpath.join("$env:USERPROFILE\\AppData\\Local\\Temp", src_path.name)
+            dst_path = posixpath.join(
+                "C:\\Windows\\System32\\Config\\systemprofile\\AppData\\Local\\Temp", src_path.name
+            )
         LOG.info(f"The service model will be copied to {dst_path} on the Worker environment")
         file_mappings.append((str(src_path), dst_path))
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

1.  The `WindowsInstanceWorkerBase` class contained code that attempted to resolve paths to files transfered in userdata. The paths came from the `worker_config` fixture and used `$env:USERPROFILE` to form the path. This code would run in the context of an SSM command.

    While the userdata formed paths using this same `$env:USERPROFILE` variable, the variable's value changes depending on the user running the code. On Windows, userdata runs as the system user and the variable resolves to: `C:\Windows\System32\Config\systemprofile`. But when running through SSM commands (which the `worker_config` fixture does), the variable becomes the home directory of the SSM user.

2.  The SSM command run by the `WindowsInstanceWorkerBase` to configure the worker and leverages the paths above would silently fail

### What was the solution? (How)

1.  Change the code running in the SSM command to use the hard-coded path of `C:\Windows\System32\Config\systemprofile` so it matches the path used in userdata.
2.  Add an `$ErrorActionPreference = 'Stop'` statement to the beginning of the configure worker SSM command

### What is the impact of this change?

1.  The `WindowsInstanceWorkerBase` class will use the correct paths when working with the files pulled from S3 in userdata.
2.  Errors in the configure worker command for subclasses of `WindowsInstanceWorkerBase` will not silently fail.

### How was this change tested?

1.  Modified the worker agent e2e tests to not override the `worker_config` fixture
2.  Installed the code from this PR into the worker agent hatch environment
3.  Ran the worker agent e2e Windows tests and confirmed they passed

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*