### PR TITLE
feat: ability to supply openjd-sessions Python wheel

### DIFF
--- a/src/deadline_test_fixtures/example_config.sh
+++ b/src/deadline_test_fixtures/example_config.sh
@@ -42,6 +42,10 @@ export AWS_DATA_PATH
 # Default is to pip install the latest "deadline-cloud-worker-agent" package
 export WORKER_AGENT_WHL_PATH
 
+# Local path to the openjd-sessions .whl file to use for the tests
+# Default is to pip install the latest openjd-sessions package
+export OPENJD_SESSIONS_WHL_PATH
+
 # DEPRECATED: Use REGION instead
 # The AWS region to configure the worker for
 # Falls back to AWS_DEFAULT_REGION, then defaults to us-west-2

--- a/src/deadline_test_fixtures/models.py
+++ b/src/deadline_test_fixtures/models.py
@@ -48,6 +48,12 @@ class JobRunAsUser:
 class OperatingSystem:
     name: Literal["AL2023", "WIN2022"]
 
+    def is_amazon_linux(self) -> bool:
+        return self.name.startswith("AL")
+
+    def is_windows(self) -> bool:
+        return self.name.startswith("WIN")
+
 
 @dataclass(frozen=True)
 class CodeArtifactRepositoryInfo:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

There is no ability to supply a custom developer version of `openjd-sessions` and have it deployed with the worker instances launched by `deadline-cloud-test-fixtures`

### What was the solution? (How)

Introduce a new `OPENJD_SESSIONS_WHL_PATH` environment variable that contains a glob pattern resolving to a local path to a `.whl` file for `openjd-sessions` on the test machine. This works the same as the existing `WORKER_AGENT_WHL_PATH` environment variable for supplying a custom developer version of the worker agent.

### What is the impact of this change?

Consumers of the library can orchestrate tests of workers using a custom supplied `openjd-sessions` Python library.

### How was this change tested?

1.  Modified the worker agent e2e test suite to extend the `worker_config` fixture from `deadline-cloud-test-fixtures` instead of reimplementing it
2. Set the `OPENJD_SESSIONS_WHL_PATH` to the path of a developer-built `.whl` file
3. Ran the tests
4. Inspected the worker logs sent to CloudWatch and confirmed the `openjd-sessions` version reported at the top matched the local version specified in `OPENJD_SESSIONS_WHL_PATH`

### Was this change documented?

Yes, the new environment variable was added to `src/deadline_test_fixtures/example_config.sh` where the other environment variables are documented.

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*