### PR TITLE
chore: increase retires for deadline client in worker fixture

### DIFF
--- a/src/deadline_test_fixtures/fixtures.py
+++ b/src/deadline_test_fixtures/fixtures.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import botocore
 import botocore.client
 import botocore.loaders
+import botocore.config
+from botocore.config import Config
 import boto3
 import glob
 import json
@@ -591,7 +593,9 @@ def worker(
         ec2_client = boto3.client("ec2")
         s3_client = boto3.client("s3")
         ssm_client = boto3.client("ssm")
-        deadline_client = boto3.client("deadline")
+
+        config = Config(retries={"max_attempts": 10, "mode": "standard"})
+        deadline_client = boto3.client("deadline", config=config)
 
         worker = ec2_worker_type(
             ec2_client=ec2_client,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
A user running multiple worker tests with the fixtures simultaneous can result in throttling from the service. causing false negative testing failures 

### What was the solution? (How)
Added retries to the deadline client in the `worker` test fixtures

### What is the impact of this change?
increase resilience to throttling

### How was this change tested?
Ran the test sequences using test fixtures

### Was this change documented?
no

### Is this a breaking change?
no
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*