### PR TITLE
fix: increase disk size temporarily to allow more than 4GB of free space on windows

### DIFF
--- a/src/deadline_test_fixtures/deadline/worker.py
+++ b/src/deadline_test_fixtures/deadline/worker.py
@@ -358,7 +358,9 @@ class EC2InstanceWorker(DeadlineWorker):
                 sort_keys=True,
             )
         )
+
         run_instance_response = self.ec2_client.run_instances(
+            BlockDeviceMappings=[{"DeviceName": "/dev/sda1", "Ebs": {"VolumeSize": 60}}],
             MinCount=1,
             MaxCount=1,
             ImageId=self.ami_id,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We only had 4GB of disk space available on the latest windows server 2022 ami.

How to specify disk space: 


* https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_RunInstances.html
  * https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_BlockDeviceMapping.html
     * https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_EbsBlockDevice.html

### What was the solution? (How)

increase the disk size for all instances temporarily to allow the canaries to continue to pass. We'll want to scope this down to less for Linux since it's wasted space.

### What is the impact of this change?

tests should pass

### How was this change tested?

Charles ran a script that launched an instance with the additional device block mapping structure
```
import boto3

ec2_client = boto3.client('ec2')

ec2_client.run_instances(
    
    BlockDeviceMappings=[{
        "DeviceName": "/dev/sda1",
        "Ebs": { "VolumeSize": 60},
    }],
    MinCount=1,
    MaxCount=1,
    ImageId="ami-0179b254e6670b995",
    InstanceType="t2.micro",
    SubnetId="subnet-050a857aef2bddc9e",
    SecurityGroupIds=["sg-018843f6bd3042762"],
    MetadataOptions={"HttpTokens": "required", "HttpEndpoint": "enabled"},
    TagSpecifications=[
        {
            "ResourceType": "instance",
            "Tags": [
                {
                    "Key": "InstanceIdentification",
                    "Value": "DeadlineScaffoldingWorker",
                }
            ],
        }
    ],
)
```

### Was this change documented?

N/A

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*