### PR TITLE
fix: linux instance has unused ebs block device

### DIFF
--- a/src/deadline_test_fixtures/deadline/worker.py
+++ b/src/deadline_test_fixtures/deadline/worker.py
@@ -175,8 +175,14 @@ class EC2InstanceWorker(DeadlineWorker):
     def get_worker_id(self) -> str:
         raise NotImplementedError("'get_worker_id' was not implemented.")
 
+    @abc.abstractmethod
     def userdata(self, s3_files) -> str:
         raise NotImplementedError("'userdata' was not implemented.")
+
+    @abc.abstractmethod
+    def ebs_devices(self) -> dict[str, int] | None:
+        """DeviceName -> VolumeSize (in GiBs) mapping"""
+        raise NotImplementedError("'ebs_devices' was not implemented.")
 
     def start(self) -> None:
         s3_files = self._stage_s3_bucket()
@@ -363,17 +369,16 @@ class EC2InstanceWorker(DeadlineWorker):
             )
         )
 
-        run_instance_response = self.ec2_client.run_instances(
-            BlockDeviceMappings=[{"DeviceName": "/dev/sda1", "Ebs": {"VolumeSize": 60}}],
-            MinCount=1,
-            MaxCount=1,
-            ImageId=self.ami_id,
-            InstanceType=self.instance_type,
-            IamInstanceProfile={"Name": self.instance_profile_name},
-            SubnetId=self.subnet_id,
-            SecurityGroupIds=[self.security_group_id],
-            MetadataOptions={"HttpTokens": "required", "HttpEndpoint": "enabled"},
-            TagSpecifications=[
+        run_instance_request = {
+            "MinCount": 1,
+            "MaxCount": 1,
+            "ImageId": self.ami_id,
+            "InstanceType": self.instance_type,
+            "IamInstanceProfile": {"Name": self.instance_profile_name},
+            "SubnetId": self.subnet_id,
+            "SecurityGroupIds": [self.security_group_id],
+            "MetadataOptions": {"HttpTokens": "required", "HttpEndpoint": "enabled"},
+            "TagSpecifications": [
                 {
                     "ResourceType": "instance",
                     "Tags": [
@@ -384,9 +389,18 @@ class EC2InstanceWorker(DeadlineWorker):
                     ],
                 }
             ],
-            InstanceInitiatedShutdownBehavior=self.instance_shutdown_behavior,
-            UserData=self.userdata(s3_files),
-        )
+            "InstanceInitiatedShutdownBehavior": self.instance_shutdown_behavior,
+            "UserData": self.userdata(s3_files),
+        }
+
+        devices = self.ebs_devices() or {}
+        device_mappings = [
+            {"DeviceName": name, "Ebs": {"VolumeSize": size}} for name, size in devices.items()
+        ]
+        if device_mappings:
+            run_instance_request["BlockDeviceMappings"] = device_mappings
+
+        run_instance_response = self.ec2_client.run_instances(**run_instance_request)
 
         self.instance_id = run_instance_response["Instances"][0]["InstanceId"]
         LOG.info(f"Launched EC2 instance {self.instance_id}")
@@ -427,6 +441,11 @@ class WindowsInstanceWorkerBase(EC2InstanceWorker):
     2. A host that already has the worker agent, job/agent users, and the like baked into
        the host AMI in a location & manner that may differ from case (1).
     """
+
+    def ebs_devices(self) -> dict[str, int] | None:
+        """DeviceName -> VolumeSize (in GiBs) mapping"""
+        # defaults to 60GB to match SMF, aws gives 30GB by default
+        return {"/dev/sda1": 60}
 
     def ssm_document_name(self) -> str:
         return "AWS-RunPowerShellScript"
@@ -625,6 +644,11 @@ class PosixInstanceWorkerBase(EC2InstanceWorker):
     2. A host that already has the worker agent, job/agent users, and the like baked into
        the host AMI in a location & manner that may differ from case (1).
     """
+
+    def ebs_devices(self) -> dict[str, int] | None:
+        """DeviceName -> VolumeSize (in GiBs) mapping"""
+        # defaults to 30GB to match SMF, aws gives 8GB by default
+        return {"/dev/xvda": 30}
 
     def ssm_document_name(self) -> str:
         return "AWS-RunShellScript"


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

A recent Windows Server 2022 AMI was released that had less than 6GB available of free space when launched with the default storage (30GB). To test that we can cancel the job attachments sync action we leverage transferring a 6GB file to give us the required time.

As a quick change to fix tests, we bumped the storage to 60GB on launch in https://github.com/aws-deadline/deadline-cloud-test-fixtures/pull/168

However in our effort to move quick and fix Windows, we affected the Linux instances as well by adding an unused block device.

Current Storage:

Windows
<img width="754" alt="image" src="https://github.com/user-attachments/assets/187575c7-061e-4f3b-a274-563bbb120846" />

(Looks like the AMI that decreased the free space was rolled back)
```sh
PS C:\Windows\system32> Get-PSDrive

Name           Used (GB)     Free (GB) Provider      Root                                                                                                                   CurrentLocation
----           ---------     --------- --------      ----                                                                                                                   ---------------
Alias                                  Alias
C                  22.04          7.45 FileSystem    C:\       
```

Linux
<img width="743" alt="image" src="https://github.com/user-attachments/assets/1388c1b5-c47a-4103-86bf-67384fadc2f8" />

```sh
sh-5.2$ df -h
Filesystem      Size  Used Avail Use% Mounted on
devtmpfs        4.0M     0  4.0M   0% /dev
tmpfs           475M     0  475M   0% /dev/shm
tmpfs           190M  436K  190M   1% /run
/dev/xvda1      8.0G  1.6G  6.5G  20% /
tmpfs           475M     0  475M   0% /tmp
/dev/xvda128     10M  1.3M  8.7M  13% /boot/efi
```

Linux is really close to using up all the disk space as well.

### What was the solution? (How)

Allow consumers of the test fixtures to change the block storage.

### What is the impact of this change?

We're not flying so close to the proverbial sun (available disk space) which will help give confidence in our tests that rely

### How was this change tested?

using the test fixtures, I started a `PosixInstanceBuildWorker` and a `WindowsInstanceBuildWorker`.

Linux:

![image](https://github.com/user-attachments/assets/0fd38177-fad2-44df-9d23-c91092ff07ef)

Windows:

![image](https://github.com/user-attachments/assets/a3b77bf8-4dbd-4535-86dd-e6ec93626e7a)

### Was this change documented?

N/A

### Is this a breaking change?

The additional storage device for linux was not a feature but a bug. This is fixing that bug, and is thus not a breaking change.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*