### PR TITLE
chore: Increase instance waiter retries from 60 to 75

### DIFF
--- a/src/deadline_test_fixtures/deadline/worker.py
+++ b/src/deadline_test_fixtures/deadline/worker.py
@@ -409,7 +409,7 @@ class EC2InstanceWorker(DeadlineWorker):
         instance_running_waiter = self.ec2_client.get_waiter("instance_status_ok")
         instance_running_waiter.wait(
             InstanceIds=[self.instance_id],
-            WaiterConfig={"Delay": 15, "MaxAttempts": 60},
+            WaiterConfig={"Delay": 15, "MaxAttempts": 75},
         )
         LOG.info(f"EC2 instance {self.instance_id} status is OK")
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We had a test failure where the EC2 waiter timed out before launching an instance, but after rerunning the test it didn't reoccur.

### What was the solution? (How)
Increased waiter retries from 60 to 75 retries (15 minutes -> 18 minutes). This is likely a band-aid solution but we can see if the same issues resurface.

### What is the impact of this change?
Tests will be more reliable? Maybe?

### How was this change tested?
Existing unit tests didn't break.

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*