### PR TITLE
chore: Update the version of Python in the Windows UserData to 3.12.8

### DIFF
--- a/src/deadline_test_fixtures/deadline/worker.py
+++ b/src/deadline_test_fixtures/deadline/worker.py
@@ -609,11 +609,11 @@ class WindowsInstanceBuildWorker(WindowsInstanceWorkerBase):
 
         userdata = f"""<powershell>
 $ProgressPreference = 'SilentlyContinue'
-Invoke-WebRequest -Uri "https://www.python.org/ftp/python/3.11.9/python-3.11.9-amd64.exe" -OutFile "C:\python-3.11.9-amd64.exe"
-$installerHash=(Get-FileHash "C:\python-3.11.9-amd64.exe" -Algorithm "MD5")
-$expectedHash="e8dcd502e34932eebcaf1be056d5cbcd"
+Invoke-WebRequest -Uri "https://www.python.org/ftp/python/3.12.8/python-3.12.8-amd64.exe" -OutFile "C:\python-3.12.8-amd64.exe"
+$installerHash=(Get-FileHash "C:\python-3.12.8-amd64.exe" -Algorithm "MD5")
+$expectedHash="2f2ab2472a6aa29f8755c72c58f58f4b"
 if ($installerHash.Hash -ne $expectedHash) {{ throw "Could not verify Python installer." }}
-Start-Process -FilePath "C:\python-3.11.9-amd64.exe" -ArgumentList "/quiet InstallAllUsers=1 PrependPath=1 AppendPath=1" -Wait
+Start-Process -FilePath "C:\python-3.12.8-amd64.exe" -ArgumentList "/quiet InstallAllUsers=1 PrependPath=1 AppendPath=1" -Wait
 Invoke-WebRequest -Uri "https://awscli.amazonaws.com/AWSCLIV2.msi" -Outfile "C:\AWSCLIV2.msi"
 Start-Process msiexec.exe -ArgumentList "/i C:\AWSCLIV2.msi /quiet" -Wait
 $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The Windows UserData was installing Python 3.11.9 which is out of date. More recent versions of Python 3.11 have not received Windows installers.

### What was the solution? (How)
Update to Python 3.12.8 as there are still Windows installers published for new versions of Python 3.12

### What is the impact of this change?
The Python version installed on Windows instances will be up to date.

### How was this change tested?
I ran the Windows end to end tests for the worker agent.

### Was this change documented?
N/A

### Is this a breaking change?
No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*