### PR TITLE
feat: append additional configuration to deadline-worker systemd config during linux worker setup

### DIFF
--- a/src/deadline_test_fixtures/deadline/worker.py
+++ b/src/deadline_test_fixtures/deadline/worker.py
@@ -698,7 +698,7 @@ class PosixInstanceWorkerBase(EC2InstanceWorker):
         cmds.extend(
             [
                 "mkdir -p /etc/systemd/system/deadline-worker.service.d/",
-                'echo "[Service]" > /etc/systemd/system/deadline-worker.service.d/config.conf',
+                'echo "[Service]" >> /etc/systemd/system/deadline-worker.service.d/config.conf',
                 # Configure the region
                 f'echo "Environment=AWS_REGION={config.region}" >> /etc/systemd/system/deadline-worker.service.d/config.conf',
                 f'echo "Environment=AWS_DEFAULT_REGION={config.region}" >> /etc/systemd/system/deadline-worker.service.d/config.conf',


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
Worker configuration in test fixture overwrites existing `deadline-worker.service.d/config.conf`, this cleans up the existing configuration prior to running this setup.

### What was the solution? (How)
Append additional configuration rather than overwriting the existing configuration.

### What is the impact of this change?
Allow deadline-worker.service.d/config.conf creation elsewhere and only expend additional config at end of file

### How was this change tested?
Running through the following commands
```
~> rm -r -f /tmp/systemd/system/deadline-worker.service.d/
~> mkdir -p /tmp/systemd/system/deadline-worker.service.d/
~> mkdir -p /tmp/systemd/system/deadline-worker.service.d/
~> echo "[Service]" >> /tmp/systemd/system/deadline-worker.service.d/config
~> cat /tmp/systemd/system/deadline-worker.service.d/config
[Service]
~> echo "Environment=AWS_REGION=us-west-2" >> /tmp/systemd/system/deadline-worker.service.d/config
~> cat /tmp/systemd/system/deadline-worker.service.d/config
[Service]
Environment=AWS_REGION=us-west-2
~> echo "[Service]" >> /tmp/systemd/system/deadline-worker.service.d/config
~> cat /tmp/systemd/system/deadline-worker.service.d/config
[Service]
Environment=AWS_REGION=us-west-2
[Service]
~> echo "Environment=STAGE=alpha" >> /tmp/systemd/system/deadline-worker.service.d/config
~> cat /tmp/systemd/system/deadline-worker.service.d/config
[Service]
Environment=AWS_REGION=us-west-2
[Service]
Environment=STAGE=alpha
```


### Was this change documented?
N/A

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*