### PR TITLE
test: Adjust workers for start service disabled

### DIFF
--- a/src/deadline_test_fixtures/deadline/worker.py
+++ b/src/deadline_test_fixtures/deadline/worker.py
@@ -239,6 +239,23 @@ class EC2InstanceWorker(DeadlineWorker):
         else:
             raise TimeoutError
 
+    def wait_until_worker_stopping(
+        self, *, max_checks: int = 25, seconds_between_checks: float = 5
+    ) -> None:
+        for _ in range(max_checks):
+            response = self.deadline_client.get_worker(
+                farmId=self.configuration.farm_id,
+                fleetId=self.configuration.fleet.id,
+                workerId=self.worker_id,
+            )
+            if response["status"] == "STOPPING":
+                LOG.info(f"{self.worker_id} is STOPPING")
+                break
+            time.sleep(seconds_between_checks)
+            LOG.info(f"Waiting for {self.worker_id} to transition to STOPPING status")
+        else:
+            raise TimeoutError
+
     def set_stopped_status(self):
         LOG.info(f"Setting {self.worker_id} to STOPPED status")
         try:
@@ -457,21 +474,13 @@ class WindowsInstanceWorkerBase(EC2InstanceWorker):
         cmd_result = self.send_command(
             f"{self.configure_worker_command(config=self.configuration)}"
         )
+        assert cmd_result.exit_code == 0, f"Failed to configure Worker agent: {cmd_result}"
         LOG.info("Successfully configured Worker agent")
-        LOG.info("Sending SSM Command to check if Worker Agent is running")
-        cmd_result = self.send_command(
-            " ; ".join(
-                [
-                    "echo 'Running Get-Process to check if the agent is running'",
-                    'for($i=1; $i -le 30 -and "" -ne $err ; $i++){sleep $i; Get-Process pythonservice -ErrorVariable err}',
-                    "IF(Get-Process pythonservice){echo '+++SERVICE IS RUNNING+++'}ELSE{echo '+++SERVICE NOT RUNNING+++'; Get-Content -Encoding utf8 C:\ProgramData\Amazon\Deadline\Logs\worker-agent-bootstrap.log,C:\ProgramData\Amazon\Deadline\Logs\worker-agent.log; exit 1}",
-                ]
-            ),
-        )
-        assert cmd_result.exit_code == 0, f"Failed to start Worker agent: {cmd_result}"
-        LOG.info("Successfully started Worker agent")
 
-        self.worker_id = self.get_worker_id()
+        if self.configuration.start_service:
+            LOG.info(f"Sending SSM command to start Worker agent on instance {self.instance_id}")
+            self.start_worker_service()
+            LOG.info("Successfully started Worker agent")
 
     def configure_worker_common(self, *, config: DeadlineWorkerConfiguration) -> str:
         """Get the command to configure the Worker. This must be run as Administrator.
@@ -514,11 +523,22 @@ class WindowsInstanceWorkerBase(EC2InstanceWorker):
         return "; ".join(cmds)
 
     def start_worker_service(self):
-        LOG.info("Sending command to start the Worker Agent service")
+        LOG.info("Sending command to start the Worker Agent service - Added comma")
 
-        cmd_result = self.send_command('Start-Service -Name "DeadlineWorker"')
+        cmd_result = self.send_command(
+            " ; ".join(
+                [
+                    'Start-Service -Name "DeadlineWorker"',
+                    "echo 'Running Get-Process to check if the agent is running'",
+                    'for($i=1; $i -le 30 -and "" -ne $err ; $i++){sleep $i; Get-Process pythonservice -ErrorVariable err}',
+                    "IF(Get-Process pythonservice){echo '+++SERVICE IS RUNNING+++'}ELSE{echo '+++SERVICE NOT RUNNING+++'; Get-Content -Encoding utf8 C:\ProgramData\Amazon\Deadline\Logs\worker-agent-bootstrap.log,C:\ProgramData\Amazon\Deadline\Logs\worker-agent.log; exit 1}",
+                ]
+            ),
+        )
 
         assert cmd_result.exit_code == 0, f"Failed to start Worker Agent service: : {cmd_result}"
+
+        self.worker_id = self.get_worker_id()
 
     def stop_worker_service(self):
         LOG.info("Sending command to stop the Worker Agent service")
@@ -527,6 +547,7 @@ class WindowsInstanceWorkerBase(EC2InstanceWorker):
         assert cmd_result.exit_code == 0, f"Failed to stop Worker Agent service: : {cmd_result}"
 
     def get_worker_id(self) -> str:
+        LOG.info(f"Sending SSM command to get the worker ID on instance {self.instance_id}")
         cmd_result = self.send_command(
             " ; ".join(
                 [
@@ -542,6 +563,8 @@ class WindowsInstanceWorkerBase(EC2InstanceWorker):
         assert re.match(
             r"^worker-[0-9a-f]{32}$", worker_id
         ), f"Got nonvalid Worker ID from command stdout: {cmd_result}"
+
+        LOG.info(f"Obtained Worker ID: {worker_id}")
         return worker_id
 
 
@@ -674,8 +697,6 @@ class PosixInstanceWorkerBase(EC2InstanceWorker):
             self.start_worker_service()
             LOG.info("Successfully started worker agent")
 
-        self.worker_id = self.get_worker_id()
-
     def configure_agent_user_environment(
         self, config: DeadlineWorkerConfiguration
     ) -> str:  # pragma: no cover
@@ -741,6 +762,8 @@ class PosixInstanceWorkerBase(EC2InstanceWorker):
         )
 
         assert cmd_result.exit_code == 0, f"Failed to start Worker Agent service: {cmd_result}"
+
+        self.worker_id = self.get_worker_id()
 
     def stop_worker_service(self):
         LOG.info("Sending command to stop the Worker Agent service")

--- a/src/deadline_test_fixtures/deadline/worker.py
+++ b/src/deadline_test_fixtures/deadline/worker.py
@@ -238,13 +238,13 @@ class EC2InstanceWorker(DeadlineWorker):
         except botocore.exceptions.ClientError as error:
             LOG.exception(f"Failed to delete worker: {error}")
             raise
-        
+
     def wait_until_desired_worker_status(
-            self,
-            *,
-            max_checks: int = 25,
-            seconds_between_checks: float = 5,
-            desired_status: str = "STOPPED",
+        self,
+        *,
+        max_checks: int = 25,
+        seconds_between_checks: float = 5,
+        desired_status: str = "STOPPED",
     ) -> None:
         for _ in range(max_checks):
             response = self.deadline_client.get_worker(

--- a/src/deadline_test_fixtures/deadline/worker.py
+++ b/src/deadline_test_fixtures/deadline/worker.py
@@ -214,7 +214,7 @@ class EC2InstanceWorker(DeadlineWorker):
 
         if not self.configuration.fleet.autoscaling:
             try:
-                self.wait_until_desired_worker_status(desired_status="STOPPED")
+                self.wait_until_stopped()
             except TimeoutError:
                 LOG.warning(
                     f"{self.worker_id} did not transition to a STOPPED status, forcibly stopping..."
@@ -238,6 +238,15 @@ class EC2InstanceWorker(DeadlineWorker):
         except botocore.exceptions.ClientError as error:
             LOG.exception(f"Failed to delete worker: {error}")
             raise
+
+    def wait_until_stopped(
+        self, *, max_checks: int = 25, seconds_between_checks: float = 5
+    ) -> None:
+        self.wait_until_desired_worker_status(
+            max_checks=max_checks,
+            seconds_between_checks=seconds_between_checks,
+            desired_status="STOPPED",
+        )
 
     def wait_until_desired_worker_status(
         self,

--- a/src/deadline_test_fixtures/deadline/worker.py
+++ b/src/deadline_test_fixtures/deadline/worker.py
@@ -214,7 +214,7 @@ class EC2InstanceWorker(DeadlineWorker):
 
         if not self.configuration.fleet.autoscaling:
             try:
-                self.wait_until_stopped()
+                self.wait_until_desired_worker_status(desired_status="STOPPED")
             except TimeoutError:
                 LOG.warning(
                     f"{self.worker_id} did not transition to a STOPPED status, forcibly stopping..."
@@ -238,9 +238,13 @@ class EC2InstanceWorker(DeadlineWorker):
         except botocore.exceptions.ClientError as error:
             LOG.exception(f"Failed to delete worker: {error}")
             raise
-
-    def wait_until_stopped(
-        self, *, max_checks: int = 25, seconds_between_checks: float = 5
+        
+    def wait_until_desired_worker_status(
+            self,
+            *,
+            max_checks: int = 25,
+            seconds_between_checks: float = 5,
+            desired_status: str = "STOPPED",
     ) -> None:
         for _ in range(max_checks):
             response = self.deadline_client.get_worker(
@@ -248,28 +252,11 @@ class EC2InstanceWorker(DeadlineWorker):
                 fleetId=self.configuration.fleet.id,
                 workerId=self.worker_id,
             )
-            if response["status"] == "STOPPED":
-                LOG.info(f"{self.worker_id} is STOPPED")
+            if response["status"] == desired_status:
+                LOG.info(f"{self.worker_id} is {desired_status}")
                 break
             time.sleep(seconds_between_checks)
-            LOG.info(f"Waiting for {self.worker_id} to transition to STOPPED status")
-        else:
-            raise TimeoutError
-
-    def wait_until_worker_stopping(
-        self, *, max_checks: int = 25, seconds_between_checks: float = 5
-    ) -> None:
-        for _ in range(max_checks):
-            response = self.deadline_client.get_worker(
-                farmId=self.configuration.farm_id,
-                fleetId=self.configuration.fleet.id,
-                workerId=self.worker_id,
-            )
-            if response["status"] == "STOPPING":
-                LOG.info(f"{self.worker_id} is STOPPING")
-                break
-            time.sleep(seconds_between_checks)
-            LOG.info(f"Waiting for {self.worker_id} to transition to STOPPING status")
+            LOG.info(f"Waiting for {self.worker_id} to transition to {desired_status} status")
         else:
             raise TimeoutError
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- The tests would fail if the start-service flag was set to false
- Windows instances didn't check if the flag was enabled or not
- Linux used the `get_worker_id()`, even if the worker wasn't started 

### What was the solution? (How)
- Added the start service check to the Windows `_start_worker_agent()` function
- Simplified the `start_worker_service()` function
- Changed when calling `get_worker_id()`

### What is the impact of this change?
Improves test framework to handle the start-service flag

### How was this change tested?
Verified locally against the Windows and Linux E2E tests

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*