### PR TITLE
feat: Allow providing agent user credentials as a secrets manager secret

### DIFF
--- a/src/deadline_test_fixtures/deadline/worker.py
+++ b/src/deadline_test_fixtures/deadline/worker.py
@@ -120,6 +120,7 @@ class DeadlineWorkerConfiguration:
 
     job_user: str = field(default="job-user")
     agent_user: str = field(default="deadline-worker")
+    windows_user_secret: str | None = None
     job_user_group: str = field(default="deadline-job-users")
 
     job_users: list[PosixSessionUser] = field(
@@ -171,8 +172,8 @@ class EC2InstanceWorker(DeadlineWorker):
         raise NotImplementedError("'ssm_document_name' was not implemented.")
 
     @abc.abstractmethod
-    def _start_worker_agent(self) -> None:  # pragma: no cover
-        raise NotImplementedError("'_start_worker_agent' was not implemented.")
+    def _setup_worker_agent(self) -> None:  # pragma: no cover
+        raise NotImplementedError("'_setup_worker_agent' was not implemented.")
 
     @abc.abstractmethod
     def configure_worker_command(
@@ -204,7 +205,7 @@ class EC2InstanceWorker(DeadlineWorker):
     def start(self) -> None:
         s3_files = self._stage_s3_bucket()
         self._launch_instance(s3_files=s3_files)
-        self._start_worker_agent()
+        self._setup_worker_agent()
 
     def stop(self) -> None:
         LOG.info(f"Terminating EC2 instance {self.instance_id}")
@@ -522,7 +523,7 @@ class WindowsInstanceWorkerBase(EC2InstanceWorker):
     def ssm_document_name(self) -> str:
         return "AWS-RunPowerShellScript"
 
-    def _start_worker_agent(self) -> None:
+    def _setup_worker_agent(self) -> None:
         assert self.instance_id
         LOG.info(f"Sending SSM command to configure Worker agent on instance {self.instance_id}")
 
@@ -533,7 +534,9 @@ class WindowsInstanceWorkerBase(EC2InstanceWorker):
         LOG.info("Successfully configured Worker agent")
 
         if self.configuration.start_service:
-            LOG.info(f"Sending SSM command to start Worker agent on instance {self.instance_id}")
+            LOG.info(
+                f"Sending SSM command to start Windows Worker agent on instance {self.instance_id}"
+            )
             self.start_worker_service()
             LOG.info("Successfully started Worker agent")
 
@@ -578,7 +581,7 @@ class WindowsInstanceWorkerBase(EC2InstanceWorker):
         return "; ".join(cmds)
 
     def start_worker_service(self):
-        LOG.info("Sending command to start the Worker Agent service - Added comma")
+        LOG.info("Sending command to start the Worker Agent service")
 
         cmd_result = self.send_command(
             " ; ".join(
@@ -586,7 +589,7 @@ class WindowsInstanceWorkerBase(EC2InstanceWorker):
                     'Start-Service -Name "DeadlineWorker"',
                     "echo 'Running Get-Process to check if the agent is running'",
                     'for($i=1; $i -le 30 -and "" -ne $err ; $i++){sleep $i; Get-Process pythonservice -ErrorVariable err}',
-                    "IF(Get-Process pythonservice){echo '+++SERVICE IS RUNNING+++'}ELSE{echo '+++SERVICE NOT RUNNING+++'; Get-Content -Encoding utf8 C:\ProgramData\Amazon\Deadline\Logs\worker-agent-bootstrap.log,C:\ProgramData\Amazon\Deadline\Logs\worker-agent.log; exit 1}",
+                    "IF(Get-Process pythonservice){echo '+++SERVICE IS RUNNING+++'}ELSE{echo '+++SERVICE NOT RUNNING+++'; Get-Content -Encoding utf8 C:\\ProgramData\\Amazon\\Deadline\\Logs\\worker-agent-bootstrap.log,C:\\ProgramData\\Amazon\\Deadline\\Logs\\worker-agent.log; exit 1}",
                 ]
             ),
         )
@@ -606,8 +609,8 @@ class WindowsInstanceWorkerBase(EC2InstanceWorker):
         cmd_result = self.send_command(
             " ; ".join(
                 [
-                    'for($i=1; $i -le 20 -and "" -ne $err ; $i++){sleep $i; Get-Item C:\ProgramData\Amazon\Deadline\Cache\worker.json -ErrorVariable err 1>$null}',
-                    "$worker=Get-Content -Raw C:\ProgramData\Amazon\Deadline\Cache\worker.json | ConvertFrom-Json",
+                    'for($i=1; $i -le 20 -and "" -ne $err ; $i++){sleep $i; Get-Item C:\\ProgramData\\Amazon\\Deadline\\Cache\\worker.json -ErrorVariable err 1>$null}',
+                    "$worker=Get-Content -Raw C:\\ProgramData\\Amazon\\Deadline\\Cache\\worker.json | ConvertFrom-Json",
                     "echo $worker.worker_id",
                 ]
             ),
@@ -623,6 +626,20 @@ class WindowsInstanceWorkerBase(EC2InstanceWorker):
         LOG.info(f"Obtained Worker ID: {worker_id}")
         return worker_id
 
+    def get_windows_user_secret(self, secret_id: str) -> CommandResult:
+        """
+        Retrieves a secret from AWS Secrets Manager.
+        """
+        cmd = (
+            f"aws secretsmanager get-secret-value "
+            f"--secret-id {secret_id} "
+            "--query SecretString --output text "
+        )
+        result = self.send_command(cmd)
+        if result.exit_code != 0:
+            raise Exception(f"Failed to get secret: {result.stderr}")
+        return result
+
 
 @dataclass
 class WindowsInstanceBuildWorker(WindowsInstanceWorkerBase):
@@ -635,6 +652,13 @@ class WindowsInstanceBuildWorker(WindowsInstanceWorkerBase):
 
     def configure_worker_command(self, *, config: DeadlineWorkerConfiguration) -> str:
         """Get the command to configure the Worker. This must be run as Administrator."""
+
+        password = None
+        if config.windows_user_secret:
+            user_secret = self.get_windows_user_secret(secret_id=config.windows_user_secret)
+            secret_json = json.loads(user_secret.stdout)
+            password = secret_json["password"]
+        
         cmds = [
             "Set-PSDebug -trace 1",
             self.configure_worker_common(config=config),
@@ -648,6 +672,7 @@ class WindowsInstanceBuildWorker(WindowsInstanceWorkerBase):
                 + f"--fleet-id {config.fleet.id} "
                 + f"--region {config.region} "
                 + f"--user {config.agent_user} "
+                + (f"--password {password} " if password is not None else "")
                 + f"{'--allow-shutdown ' if config.allow_shutdown else ''}"
                 + f"{'--disallow-instance-profile ' if config.disallow_instance_profile else ''}"
                 + (f"--session-root-dir {config.session_root_dir} " if config.session_root_dir is not None else '')
@@ -688,13 +713,13 @@ class WindowsInstanceBuildWorker(WindowsInstanceWorkerBase):
 
         userdata = f"""<powershell>
 $ProgressPreference = 'SilentlyContinue'
-Invoke-WebRequest -Uri "https://www.python.org/ftp/python/3.12.9/python-3.12.9-amd64.exe" -OutFile "C:\python-3.12.9-amd64.exe"
-$installerHash=(Get-FileHash "C:\python-3.12.9-amd64.exe" -Algorithm "MD5")
+Invoke-WebRequest -Uri "https://www.python.org/ftp/python/3.12.9/python-3.12.9-amd64.exe" -OutFile "C:\\python-3.12.9-amd64.exe"
+$installerHash=(Get-FileHash "C:\\python-3.12.9-amd64.exe" -Algorithm "MD5")
 $expectedHash="1cfb1bbf96007b12b98db895dcd86487"
 if ($installerHash.Hash -ne $expectedHash) {{ throw "Could not verify Python installer." }}
-Start-Process -FilePath "C:\python-3.12.9-amd64.exe" -ArgumentList "/quiet InstallAllUsers=1 PrependPath=1 AppendPath=1" -Wait
-Invoke-WebRequest -Uri "https://awscli.amazonaws.com/AWSCLIV2.msi" -Outfile "C:\AWSCLIV2.msi"
-Start-Process msiexec.exe -ArgumentList "/i C:\AWSCLIV2.msi /quiet" -Wait
+Start-Process -FilePath "C:\\python-3.12.9-amd64.exe" -ArgumentList "/quiet InstallAllUsers=1 PrependPath=1 AppendPath=1" -Wait
+Invoke-WebRequest -Uri "https://awscli.amazonaws.com/AWSCLIV2.msi" -Outfile "C:\\AWSCLIV2.msi"
+Start-Process msiexec.exe -ArgumentList "/i C:\\AWSCLIV2.msi /quiet" -Wait
 $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine")
 $secret = aws secretsmanager get-secret-value --secret-id WindowsPasswordSecret --query SecretString --output text | ConvertFrom-Json
 $password = ConvertTo-SecureString -String $($secret.password) -AsPlainText -Force
@@ -737,7 +762,7 @@ class PosixInstanceWorkerBase(EC2InstanceWorker):
     ) -> CommandResult:
         return super().send_command("set -eou pipefail; " + command, ssm_waiter_config)
 
-    def _start_worker_agent(self) -> None:
+    def _setup_worker_agent(self) -> None:
         assert self.instance_id
         LOG.info(
             f"Starting worker for farm: {self.configuration.farm_id} and fleet: {self.configuration.fleet.id}"

--- a/src/deadline_test_fixtures/deadline/worker.py
+++ b/src/deadline_test_fixtures/deadline/worker.py
@@ -662,30 +662,21 @@ class WindowsInstanceBuildWorker(WindowsInstanceWorkerBase):
             self.configure_worker_common(config=config),
             config.worker_agent_install.install_command_for_windows,
             *(config.pre_install_commands or []),
+            # fmt: off
+            (
+                "install-deadline-worker "
+                + "-y "
+                + f"--farm-id {config.farm_id} "
+                + f"--fleet-id {config.fleet.id} "
+                + f"--region {config.region} "
+                + f"--user {config.agent_user} "
+                + (f"--password $({self.get_windows_user_secret_cmd(secret_id=config.windows_user_secret)}) " if config.windows_user_secret else "")
+                + f"{'--allow-shutdown ' if config.allow_shutdown else ''}"
+                + f"{'--disallow-instance-profile ' if config.disallow_instance_profile else ''}"
+                + (f"--session-root-dir {config.session_root_dir} " if config.session_root_dir is not None else '')
+            ),
+            # fmt: on
         ]
-
-        if config.windows_user_secret:
-            cmds.append(
-                f"$workerPassword = {self.get_windows_user_secret_cmd(secret_id=config.windows_user_secret)}; "
-            )
-            password_param = "--password $workerPassword"
-        else:
-            password_param = ""
-
-        # fmt: off
-        cmds.append(
-            "install-deadline-worker "
-            + "-y "
-            + f"--farm-id {config.farm_id} "
-            + f"--fleet-id {config.fleet.id} "
-            + f"--region {config.region} "
-            + f"--user {config.agent_user} "
-            + f"{password_param} "
-            + f"{'--allow-shutdown ' if config.allow_shutdown else ''}"
-            + f"{'--disallow-instance-profile ' if config.disallow_instance_profile else ''}"
-            + (f"--session-root-dir {config.session_root_dir} " if config.session_root_dir is not None else '')
-        )
-        # fmt: on
 
         if config.service_model_path:
             cmds.append(

--- a/src/deadline_test_fixtures/deadline/worker.py
+++ b/src/deadline_test_fixtures/deadline/worker.py
@@ -658,7 +658,7 @@ class WindowsInstanceBuildWorker(WindowsInstanceWorkerBase):
             user_secret = self.get_windows_user_secret(secret_id=config.windows_user_secret)
             secret_json = json.loads(user_secret.stdout)
             password = secret_json["password"]
-        
+
         cmds = [
             "Set-PSDebug -trace 1",
             self.configure_worker_common(config=config),

--- a/src/deadline_test_fixtures/deadline/worker.py
+++ b/src/deadline_test_fixtures/deadline/worker.py
@@ -626,19 +626,23 @@ class WindowsInstanceWorkerBase(EC2InstanceWorker):
         LOG.info(f"Obtained Worker ID: {worker_id}")
         return worker_id
 
-    def get_windows_user_secret(self, secret_id: str) -> CommandResult:
+    def get_windows_user_secret_cmd(self, secret_id: str) -> str:
         """
-        Retrieves a secret from AWS Secrets Manager.
+        Returns a PowerShell command string that will retrieve and use the secret on the worker instance itself.
+
+        Args:
+            secret_id: The ID of the secret in Secrets Manager
+
+        Returns:
+            str: PowerShell command to fetch and extract the password from the secret
         """
-        cmd = (
-            f"aws secretsmanager get-secret-value "
+        return (
+            "aws secretsmanager get-secret-value "
             f"--secret-id {secret_id} "
-            "--query SecretString --output text "
+            "--query 'SecretString' --output text | "
+            "ConvertFrom-Json | "
+            "Select-Object -ExpandProperty password"
         )
-        result = self.send_command(cmd)
-        if result.exit_code != 0:
-            raise Exception(f"Failed to get secret: {result.stderr}")
-        return result
 
 
 @dataclass
@@ -653,32 +657,35 @@ class WindowsInstanceBuildWorker(WindowsInstanceWorkerBase):
     def configure_worker_command(self, *, config: DeadlineWorkerConfiguration) -> str:
         """Get the command to configure the Worker. This must be run as Administrator."""
 
-        password = None
-        if config.windows_user_secret:
-            user_secret = self.get_windows_user_secret(secret_id=config.windows_user_secret)
-            secret_json = json.loads(user_secret.stdout)
-            password = secret_json["password"]
-
         cmds = [
             "Set-PSDebug -trace 1",
             self.configure_worker_common(config=config),
             config.worker_agent_install.install_command_for_windows,
             *(config.pre_install_commands or []),
-            # fmt: off
-            (
-                "install-deadline-worker "
-                + "-y "
-                + f"--farm-id {config.farm_id} "
-                + f"--fleet-id {config.fleet.id} "
-                + f"--region {config.region} "
-                + f"--user {config.agent_user} "
-                + (f"--password {password} " if password is not None else "")
-                + f"{'--allow-shutdown ' if config.allow_shutdown else ''}"
-                + f"{'--disallow-instance-profile ' if config.disallow_instance_profile else ''}"
-                + (f"--session-root-dir {config.session_root_dir} " if config.session_root_dir is not None else '')
-            ),
-            # fmt: on
         ]
+
+        if config.windows_user_secret:
+            cmds.append(
+                f"$workerPassword = {self.get_windows_user_secret_cmd(secret_id=config.windows_user_secret)}; "
+            )
+            password_param = "--password $workerPassword"
+        else:
+            password_param = ""
+
+        # fmt: off
+        cmds.append(
+            "install-deadline-worker "
+            + "-y "
+            + f"--farm-id {config.farm_id} "
+            + f"--fleet-id {config.fleet.id} "
+            + f"--region {config.region} "
+            + f"--user {config.agent_user} "
+            + f"{password_param} "
+            + f"{'--allow-shutdown ' if config.allow_shutdown else ''}"
+            + f"{'--disallow-instance-profile ' if config.disallow_instance_profile else ''}"
+            + (f"--session-root-dir {config.session_root_dir} " if config.session_root_dir is not None else '')
+        )
+        # fmt: on
 
         if config.service_model_path:
             cmds.append(

--- a/test/unit/deadline/test_worker.py
+++ b/test/unit/deadline/test_worker.py
@@ -173,7 +173,7 @@ class TestPosixInstanceBuildWorker:
         with (
             patch.object(worker, "_stage_s3_bucket", return_value=s3_files) as mock_stage_s3_bucket,
             patch.object(worker, "_launch_instance") as mock_launch_instance,
-            patch.object(worker, "_start_worker_agent") as mock_start_worker_agent,
+            patch.object(worker, "_setup_worker_agent") as mock_setup_worker_agent,
             patch.object(
                 worker,
                 "get_worker_id",
@@ -189,7 +189,7 @@ class TestPosixInstanceBuildWorker:
         # Detailed testing for each of these is done in dedicated test methods
         mock_stage_s3_bucket.assert_called_once()
         mock_launch_instance.assert_called_once_with(s3_files=s3_files)
-        mock_start_worker_agent.assert_called_once()
+        mock_setup_worker_agent.assert_called_once()
 
     def test_stage_s3_bucket(
         self,
@@ -245,7 +245,7 @@ class TestPosixInstanceBuildWorker:
     @pytest.mark.skip(
         "There's nothing to test in this method currently since it's just sending SSM commands"
     )
-    def test_start_worker_agent(self) -> None:
+    def test_setup_worker_agent(self) -> None:
         pass
 
     def test_stop(self, worker: PosixInstanceBuildWorker) -> None:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- Existing Windows worker test-fixtures created a temporary password for the agent user when installing the deadline worker. This meant that reusing or logging in as that worker agent user for debugging required resetting the password within the instance as Administrator.


### What was the solution? (How)
- If an AWS Secrets Manager secret is provided with the configuration, the Windows worker will be installed with the corresponding password.
- There was also warnings about incorrect escape characters and some additional cleanup mentioned in [PR-185](https://github.com/aws-deadline/deadline-cloud-test-fixtures/pull/185)

### What is the impact of this change?
- There should be no impact.

### How was this change tested?
- Locally verified the worker-agent Windows and Linux E2E tests were successful.
- Locally verified the test-fixture tests were successful.

### Was this change documented?
- No

### Is this a breaking change?
- No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*