### PR TITLE
fix: errors while trying to stop queue fleet associations that are already stopped/ing

### DIFF
--- a/src/deadline_test_fixtures/deadline/resources.py
+++ b/src/deadline_test_fixtures/deadline/resources.py
@@ -258,7 +258,7 @@ class QueueFleetAssociation:
         *,
         client: DeadlineClient,
         stop_mode: Literal[
-            "STOP_SCHEDULING_AND_CANCEL_TASKS", "STOP_SCHEDULING_AND_FINISH_TASKS"
+            "STOP_SCHEDULING_AND_CANCEL_TASKS", "STOP_SCHEDULING_AND_COMPLETE_TASKS"
         ] = "STOP_SCHEDULING_AND_CANCEL_TASKS",
         raw_kwargs: dict | None = None,
     ) -> None:
@@ -278,20 +278,38 @@ class QueueFleetAssociation:
         *,
         client: DeadlineClient,
         stop_mode: Literal[
-            "STOP_SCHEDULING_AND_CANCEL_TASKS", "STOP_SCHEDULING_AND_FINISH_TASKS"
+            "STOP_SCHEDULING_AND_CANCEL_TASKS", "STOP_SCHEDULING_AND_COMPLETE_TASKS"
         ] = "STOP_SCHEDULING_AND_CANCEL_TASKS",
         interval_s: int = 10,
         max_retries: int = 6,
     ) -> None:
-        call_api(
-            description=f"Set queue-fleet association to STOPPING_SCHEDULING_AND_CANCELING_TASKS for queue {self.queue.id} and fleet {self.fleet.id}",
-            fn=lambda: client.update_queue_fleet_association(
+
+        # Check the current status of the queue-fleet association
+        response = call_api(
+            description=f"Get queue-fleet association for queue {self.queue.id} and fleet {self.fleet.id}",
+            fn=lambda: client.get_queue_fleet_association(
                 farmId=self.farm.id,
                 queueId=self.queue.id,
                 fleetId=self.fleet.id,
-                status=stop_mode,
             ),
         )
+        current_qfa_status = response["status"]
+
+        if current_qfa_status == "ACTIVE" or (
+            current_qfa_status == "STOP_SCHEDULING_AND_COMPLETE_TASKS"
+            and stop_mode == "STOP_SCHEDULING_AND_CANCEL_TASKS"
+        ):
+            call_api(
+                description=f"Set queue-fleet association to {stop_mode} for queue {self.queue.id} and fleet {self.fleet.id}",
+                fn=lambda: client.update_queue_fleet_association(
+                    farmId=self.farm.id,
+                    queueId=self.queue.id,
+                    fleetId=self.fleet.id,
+                    status=stop_mode,
+                ),
+            )
+        else:
+            LOG.info(f"queue-fleet association status is already {current_qfa_status}")
 
         # Temporary until we have waiters
         valid_statuses = set(["STOPPED", stop_mode])

--- a/test/unit/deadline/test_resources.py
+++ b/test/unit/deadline/test_resources.py
@@ -574,7 +574,7 @@ class TestQueueFleetAssociation:
         "stop_mode",
         [
             "STOP_SCHEDULING_AND_CANCEL_TASKS",
-            "STOP_SCHEDULING_AND_FINISH_TASKS",
+            "STOP_SCHEDULING_AND_COMPLETE_TASKS",
         ],
     )
     def test_delete(self, stop_mode: Any, qfa: QueueFleetAssociation) -> None:
@@ -601,13 +601,14 @@ class TestQueueFleetAssociation:
             "stop_mode",
             [
                 "STOP_SCHEDULING_AND_CANCEL_TASKS",
-                "STOP_SCHEDULING_AND_FINISH_TASKS",
+                "STOP_SCHEDULING_AND_COMPLETE_TASKS",
             ],
         )
         def test_stops(self, stop_mode: Any, qfa: QueueFleetAssociation) -> None:
             # GIVEN
             mock_client = MagicMock()
             mock_client.get_queue_fleet_association.side_effect = [
+                {"status": "ACTIVE"},
                 {"status": stop_mode},
                 {"status": "STOPPED"},
             ]
@@ -623,13 +624,37 @@ class TestQueueFleetAssociation:
                 status=stop_mode,
             )
             mock_client.get_queue_fleet_association.assert_has_calls(
-                [call(farmId=qfa.farm.id, queueId=qfa.queue.id, fleetId=qfa.fleet.id)] * 2
+                [call(farmId=qfa.farm.id, queueId=qfa.queue.id, fleetId=qfa.fleet.id)] * 3
+            )
+
+        def test_cancel_while_waiting_for_complete(self, qfa: QueueFleetAssociation) -> None:
+            # GIVEN
+            mock_client = MagicMock()
+            mock_client.get_queue_fleet_association.side_effect = [
+                {"status": "STOP_SCHEDULING_AND_COMPLETE_TASKS"},
+                {"status": "STOP_SCHEDULING_AND_CANCEL_TASKS"},
+                {"status": "STOPPED"},
+            ]
+
+            # WHEN
+            qfa.stop(client=mock_client, stop_mode="STOP_SCHEDULING_AND_CANCEL_TASKS")
+
+            # THEN
+            mock_client.update_queue_fleet_association.assert_called_once_with(
+                farmId=qfa.farm.id,
+                queueId=qfa.queue.id,
+                fleetId=qfa.fleet.id,
+                status="STOP_SCHEDULING_AND_CANCEL_TASKS",
+            )
+            mock_client.get_queue_fleet_association.assert_has_calls(
+                [call(farmId=qfa.farm.id, queueId=qfa.queue.id, fleetId=qfa.fleet.id)] * 3
             )
 
         def test_raises_when_nonvalid_status_is_reached(self, qfa: QueueFleetAssociation) -> None:
             # GIVEN
             mock_client = MagicMock()
             mock_client.get_queue_fleet_association.side_effect = [
+                {"status": "ACTIVE"},
                 {"status": "BAD"},
             ]
 
@@ -645,6 +670,32 @@ class TestQueueFleetAssociation:
                 str(raised_err.value)
                 == "Association entered a nonvalid status (BAD) while waiting for the desired status: STOPPED"
             )
+
+        @pytest.mark.parametrize(
+            "status",
+            [
+                "STOP_SCHEDULING_AND_CANCEL_TASKS",
+                "STOPPED",
+            ],
+        )
+        def test_does_not_send_stop_if_stopping_or_stopped(
+            self, status: str, qfa: QueueFleetAssociation
+        ) -> None:
+            # GIVEN
+            mock_client = MagicMock()
+            mock_client.get_queue_fleet_association.side_effect = [
+                {"status": status},
+                {"status": "STOPPED"},
+            ]
+
+            # WHEN
+            qfa.stop(
+                client=mock_client,
+                stop_mode="STOP_SCHEDULING_AND_CANCEL_TASKS",
+            )
+
+            # THEN
+            mock_client.update_queue_fleet_association.assert_not_called()
 
 
 class TestJob:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
If a qfa is already set to STOP_SCHEDULING_AND_CANCEL_TASKS or STOPPED then trying to stop it again results in an uncaught exception like:
```
An error occurred (ConflictException) when calling the UpdateQueueFleetAssociation operation: Request could not be completed. Status STOP_SCHEDULING_AND_CANCEL_TASKS of resource queue-xxxxxxxxxxxxxxxxxxxxxxxxxx/fleet-xxxxxxxxxxxxxxxxxxxxxxxxxxx does not permit the operation. The valid statuses are [ACTIVE]
```

### What was the solution? (How)
* Add a check that the qfa is in ACTIVE in which case either of the stop options are valid. Add an additional check that if that status is STOP_SCHEDULING_AND_COMPLETE_TASKS that is a valid state to then set to STOP_SCHEDULING_AND_CANCEL_TASKS as well
* Renamed STOP_SCHEDULING_AND_FINISH_TASKS to STOP_SCHEDULING_AND_COMPLETE_TASKS because that is what it's actually called in the [API](https://docs.aws.amazon.com/deadline-cloud/latest/APIReference/API_UpdateQueueFleetAssociation.html)...
  * If you try to provide STOP_SCHEDULING_AND_FINISH_TASKS you'll get a validation error  :
      ```
         An error occurred (ValidationException) when calling the UpdateQueueFleetAssociation operation: [instance value ("STOP_SCHEDULING_AND_FINISH_TASKS") not found in enum (possible values: ["ACTIVE","STOP_SCHEDULING_AND_COMPLETE_TASKS","STOP_SCHEDULING_AND_CANCEL_TASKS"])]
      ```
### What is the impact of this change?
* Tests relying on these fixtures should be more reliable and you can actually set the association to wait for tasks to complete now

### How was this change tested?
* Ran existing unit tests and created new ones
* Ran some tests of QFA deletion and stopping in my own account
### Was this change documented?
No

### Is this a breaking change?

It may look like one, but I've decided not to make it one since the changes that look breaking are actually fixing things by changing STOP_SCHEDULING_AND_FINISH_TASKS to STOP_SCHEDULING_AND_COMPLETE_TASKS which as-is does not work at all.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*