### PR TITLE
feat: Retry on SSM Command undeliverable

### DIFF
--- a/src/deadline_test_fixtures/deadline/worker.py
+++ b/src/deadline_test_fixtures/deadline/worker.py
@@ -23,7 +23,7 @@ from ..models import (
     PosixSessionUser,
 )
 from .resources import CloudWatchLogEvent, Fleet, WorkerLog
-from ..util import call_api, wait_for
+from ..util import call_api, wait_for, retry_with_predicate, is_instance_not_ready
 
 if TYPE_CHECKING:
     from botocore.paginate import PageIterator, Paginator
@@ -353,6 +353,10 @@ class EC2InstanceWorker(DeadlineWorker):
 
         return WorkerLog(worker_id=self.worker_id, logs=log_events)  # type: ignore[arg-type]
 
+    @retry_with_predicate(
+        max_attempts=3, predicate=lambda e: isinstance(e, botocore.exceptions.WaiterError)
+    )
+    @retry_with_predicate(max_attempts=60, delay=10, backoff=1, predicate=is_instance_not_ready)
     def send_command(
         self, command: str, ssm_waiter_config: dict[str, int] = DEFAULT_WAITER_CONFIG
     ) -> CommandResult:
@@ -368,26 +372,20 @@ class EC2InstanceWorker(DeadlineWorker):
         #
         # If we send an SSM command then we will get an InvalidInstanceId error
         # if the instance isn't in that state.
-        NUM_RETRIES = 60
-        SLEEP_INTERVAL_S = 10
-        for i in range(0, NUM_RETRIES):
-            LOG.info(f"Sending SSM command to instance {self.instance_id}")
-            try:
-                send_command_response = self.ssm_client.send_command(
-                    InstanceIds=[self.instance_id],
-                    DocumentName=self.ssm_document_name(),
-                    Parameters={"commands": [command]},
+
+        LOG.info(f"Sending SSM command to instance {self.instance_id}")
+        try:
+            send_command_response = self.ssm_client.send_command(
+                InstanceIds=[self.instance_id],
+                DocumentName=self.ssm_document_name(),
+                Parameters={"commands": [command]},
+            )
+        except botocore.exceptions.ClientError as error:
+            if error.response["Error"]["Code"] == "InvalidInstanceId":
+                LOG.warning(
+                    f"Instance {self.instance_id} is not ready for SSM command (received InvalidInstanceId error)."
                 )
-                break
-            except botocore.exceptions.ClientError as error:
-                error_code = error.response["Error"]["Code"]
-                if error_code == "InvalidInstanceId" and i < NUM_RETRIES - 1:
-                    LOG.warning(
-                        f"Instance {self.instance_id} is not ready for SSM command (received InvalidInstanceId error). Retrying in {SLEEP_INTERVAL_S}s."
-                    )
-                    time.sleep(SLEEP_INTERVAL_S)
-                    continue
-                raise
+            raise
 
         command_id = send_command_response["Command"]["CommandId"]
 
@@ -398,8 +396,15 @@ class EC2InstanceWorker(DeadlineWorker):
                 CommandId=command_id,
                 WaiterConfig=ssm_waiter_config,
             )
-        except botocore.exceptions.WaiterError:  # pragma: no cover
-            # Swallow exception, we're going to check the result anyway
+        except botocore.exceptions.WaiterError as e:  # pragma: no cover
+            if isinstance(e, botocore.exceptions.WaiterError) and (
+                "Undeliverable" in str(e) or "Undeliverable" in str(e.last_response)
+            ):
+                # if it wasn't delivered, retry. Otherwise let's check the command result.
+                LOG.warning(
+                    f"Unable to deliver command {command_id} to instance {self.instance_id} (received UndeliverableError)."
+                )
+                raise e
             pass
 
         ssm_command_result = self.ssm_client.get_command_invocation(

--- a/src/deadline_test_fixtures/util.py
+++ b/src/deadline_test_fixtures/util.py
@@ -6,6 +6,8 @@ import botocore.exceptions
 import logging
 from time import sleep
 from typing import Any, Callable
+import functools
+
 
 LOG = logging.getLogger(__name__)
 
@@ -30,6 +32,65 @@ def wait_for(
         LOG.info(f"Retrying in {interval_s}s...")
         retry_count += 1
         sleep(interval_s)
+
+
+def is_instance_not_ready(e: Exception):
+    # Retry on the instance not being ready.
+    return (
+        isinstance(e, botocore.exceptions.ClientError)
+        and e.response["Error"]["Code"] == "InvalidInstanceId"
+    )
+
+
+def retry_with_predicate(max_attempts=3, delay=1, backoff=2, predicate=None):
+    """
+    Retry decorator with configurable parameters and exception predicate.
+
+    Args:
+        max_attempts (int): Maximum number of retry attempts
+        delay (float): Initial delay between retries in seconds
+        backoff (float): Backoff multiplier (e.g. 2 means delay doubles each retry)
+        predicate (callable): Function that takes an exception and returns True if retry should happen
+                             If None, all exceptions will trigger a retry
+
+    Returns:
+        The decorated function result if successful
+    """
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            attempts = 0
+            current_delay = delay
+
+            while attempts < max_attempts:
+                try:
+                    return func(*args, **kwargs)
+                except Exception as e:
+                    attempts += 1
+
+                    # Check if we should retry based on the exception
+                    should_retry = predicate(e) if predicate else True
+
+                    # If we shouldn't retry or we're out of attempts, raise the exception
+                    if not should_retry or attempts >= max_attempts:
+                        raise
+
+                    # Log the retry attempt
+                    logging.warning(
+                        f"Retry {attempts}/{max_attempts} for {func.__name__} due to {e.__class__.__name__}: {str(e)}. "
+                        f"Retrying in {current_delay} seconds..."
+                    )
+
+                    # Wait before retrying
+                    sleep(current_delay)
+
+                    # Increase the delay for the next attempt
+                    current_delay *= backoff
+
+        return wrapper
+
+    return decorator
 
 
 def call_api(*, description: str, fn: Callable[[], Any]) -> Any:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The SSM command waiter can fail with an "Undeliverable" error when the underlying SSM command fails to be delievered. This happens after the instance is confirmed to be running (not an `InvalidInstanceId` error). This causes the worker agent tests to be flaky.

### What was the solution? (How)

Added a retry utility decorator. Then refactored the `send_command` function.
* Moved the retry loop around the `send_command` out to the decorator, with the same number of retries and wait.
* Added a retry decorator for the `WaiterError` when the inner response is `Undeliverable`.

### What is the impact of this change?

We will perform 3 retries when a command fails to be delivered. Hopefully this makes the tests less flaky. Since we also have increased logging, this may help up further debug this issue in the future. 

### How was this change tested?

I attempted to write tests for this - however I discovered part way through that the test setup for this package is not working. Recreating in practice is difficult, since we don't have conclusive ideas about what causes this type of error.  

### Was this change documented?

No

### Is this a breaking change?

No
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*