### PR TITLE
feat: add additional debug logging when SSM waiter fails

### DIFF
--- a/src/deadline_test_fixtures/deadline/worker.py
+++ b/src/deadline_test_fixtures/deadline/worker.py
@@ -397,6 +397,10 @@ class EC2InstanceWorker(DeadlineWorker):
                 WaiterConfig=ssm_waiter_config,
             )
         except botocore.exceptions.WaiterError as e:  # pragma: no cover
+            LOG.warning(f"WaiterError caught for command {command_id}:")
+            LOG.warning(f"\tError reason: {str(e)}")
+            LOG.warning(f"\tWaiter last response: {str(e.last_response)}")
+
             if isinstance(e, botocore.exceptions.WaiterError) and (
                 "Undeliverable" in str(e) or "Undeliverable" in str(e.last_response)
             ):


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
A previous change(#196) added the ability to retry on waiter errors when the reason was that the command was undeliverable. This appears to not be working, at least not on first try. We have seen a command be marked as undeliverable now and when calling the code path it does print the message and presumably retry, but in the actual run of the tests it did not retry and did not print the message that the command was undeliverable.

### What was the solution? (How)
I'm wondering if there's an eventual consistency issue with SSM/the waiter where it is reaching a terminal failed state, but the last_response isn't actually for it being undeliverable yet.

### What is the impact of this change?
Better chance of debugging the issue further in the future. Right now the command that failed is entering the correct code path, but when the test was actually running something must have been different or returned differently.

### How was this change tested?
Just added the LOG statements to a local script where I was testing the isolated code path and verified the exceptions were printed correctly.

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*