### PR TITLE
fix: SSM waiter timeouts not long enough for Windows worker agent setup

### DIFF
--- a/src/deadline_test_fixtures/deadline/worker.py
+++ b/src/deadline_test_fixtures/deadline/worker.py
@@ -628,7 +628,8 @@ class WindowsInstanceWorkerBase(EC2InstanceWorker):
         LOG.info(f"Sending SSM command to configure Worker agent on instance {self.instance_id}")
 
         cmd_result = self.send_command(
-            f"{self.configure_worker_command(config=self.configuration)}"
+            f"{self.configure_worker_command(config=self.configuration)}",
+            {"Delay": 5, "MaxAttempts": 48},
         )
         assert cmd_result.exit_code == 0, f"Failed to configure Worker agent: {cmd_result}"
         LOG.info("Successfully configured Worker agent")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
The SSM waiter was timing out on installing the worker agent on Windows.

### What was the solution? (How)
Increase from the default 2.5min wait to 4min for some additional buffer when configuring the agent on Windows

### What is the impact of this change?
Should cause less flaky test issues

### How was this change tested?
`hatch run fmt && hatch run lint`

### Was this change documented?
No

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*