### PR TITLE
feat: add ability to tag instances

### DIFF
--- a/src/deadline_test_fixtures/__init__.py
+++ b/src/deadline_test_fixtures/__init__.py
@@ -22,6 +22,7 @@ from .deadline import (
     Step,
     Task,
     TaskStatus,
+    Ec2Tag,
 )
 from .fixtures import (
     BootstrapResources,
@@ -91,4 +92,5 @@ __all__ = [
     "version",
     "worker_config",
     "worker",
+    "Ec2Tag",
 ]

--- a/src/deadline_test_fixtures/deadline/__init__.py
+++ b/src/deadline_test_fixtures/deadline/__init__.py
@@ -36,6 +36,7 @@ from .worker import (
     WindowsInstanceWorkerBase,
     WindowsInstanceBuildWorker,
     PipInstall,
+    Ec2Tag,
 )
 
 __all__ = [
@@ -72,4 +73,5 @@ __all__ = [
     "WindowsInstanceBuildWorker",
     "WindowsInstanceWorkerBase",
     "WorkerLog",
+    "Ec2Tag",
 ]

--- a/src/deadline_test_fixtures/deadline/worker.py
+++ b/src/deadline_test_fixtures/deadline/worker.py
@@ -38,6 +38,12 @@ DEFAULT_WAITER_CONFIG = {
 }
 
 
+@dataclass
+class Ec2Tag:
+    key: str
+    value: str
+
+
 class DeadlineWorker(abc.ABC):
     @abc.abstractmethod
     def start(self) -> None:
@@ -175,6 +181,8 @@ class EC2InstanceWorker(DeadlineWorker):
 
     instance_type: str
     instance_shutdown_behavior: str
+
+    additional_tags: list[Ec2Tag] = field(default_factory=list)
 
     instance_id: Optional[str] = field(init=False, default=None)
     worker_id: Optional[str] = field(init=False, default=None)
@@ -481,6 +489,16 @@ class EC2InstanceWorker(DeadlineWorker):
                 )
             )
 
+            tags = [
+                {
+                    "Key": "InstanceIdentification",
+                    "Value": "DeadlineScaffoldingWorker",
+                }
+            ]
+
+            for tag in self.additional_tags:
+                tags.append({"Key": tag.key, "Value": tag.value})
+
             run_instance_request = {
                 "MinCount": 1,
                 "MaxCount": 1,
@@ -493,12 +511,7 @@ class EC2InstanceWorker(DeadlineWorker):
                 "TagSpecifications": [
                     {
                         "ResourceType": "instance",
-                        "Tags": [
-                            {
-                                "Key": "InstanceIdentification",
-                                "Value": "DeadlineScaffoldingWorker",
-                            }
-                        ],
+                        "Tags": tags,
                     }
                 ],
                 "InstanceInitiatedShutdownBehavior": self.instance_shutdown_behavior,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We need to be able to tag test instances with arbitrary tags. This came from the need for the Worker Agent E2E tests to be able to identify which resources were created by them, so the tests can clean up all instances safely.

### What was the solution? (How)
Allow additional tags to be passed into `DeadlineWorker`

### What is the impact of this change?
Tests can tag EC2 instances however they want.

### How was this change tested?
Brought these changes into a local Worker Agent and ensured that all of the EC2 instances the E2E tests created were tagged appropriately. 

### Was this change documented?
N/A

### Is this a breaking change?
No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*