### PR TITLE
feat: Add ability to pass env var to worker config

### DIFF
--- a/src/deadline_test_fixtures/deadline/worker.py
+++ b/src/deadline_test_fixtures/deadline/worker.py
@@ -16,7 +16,7 @@ import subprocess
 import tempfile
 import time
 from dataclasses import dataclass, field, InitVar, replace
-from typing import TYPE_CHECKING, Any, ClassVar, Optional, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Optional, cast, Dict
 
 from ..models import (
     PipInstall,
@@ -164,6 +164,9 @@ class DeadlineWorkerConfiguration:
 
     session_root_dir: str | None = None
     """Path to parent directory of worker session directories"""
+
+    worker_env_var: Dict[str, str] | None = None
+    """Additional feature flag to configure for workers"""
 
 
 @dataclass
@@ -692,6 +695,13 @@ class WindowsInstanceWorkerBase(EC2InstanceWorker):
                 "$env:AWS_ENDPOINT_URL_DEADLINE = [System.Environment]::GetEnvironmentVariable('AWS_ENDPOINT_URL_DEADLINE','Machine')",
             )
 
+        if config.worker_env_var:
+            for key, value in config.worker_env_var.items():
+                cmds.append(
+                    f"[System.Environment]::SetEnvironmentVariable('{key}', '{value}', [System.EnvironmentVariableTarget]::Machine); "
+                    f"$env:{key} = [System.Environment]::GetEnvironmentVariable('{value}','Machine')",
+                )
+
         return "; ".join(cmds)
 
     def start_worker_service(self):
@@ -938,6 +948,12 @@ class PosixInstanceWorkerBase(EC2InstanceWorker):
                 'echo "Environment=DEADLINE_WORKER_LOCAL_SESSION_LOGS=false" >> /etc/systemd/system/deadline-worker.service.d/config.conf',
             )
 
+            cmds.append("systemctl daemon-reload")
+        if config.worker_env_var:
+            for key, value in config.worker_env_var.items():
+                cmds.append(
+                    f"echo 'Environment=\"{key}={value}\"' >> /etc/systemd/system/deadline-worker.service.d/config.conf",
+                )
             cmds.append("systemctl daemon-reload")
 
         return " && ".join(cmds)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
We don't currently have a way to pass env var to worker to be set when we run tests. This will be beneficial when we need to test new feature that control by feature flag

### What was the solution? (How)
Add a new field to the worker config to accommodate the need of adding env var to worker
Add new cmd to the worker setup to make sure the env var is correctly set

### What is the impact of this change?
Test fixture now have the ability to spin up worker with sets of env var as we needed

### How was this change tested?
`hatch build` and install locally to a hatch shell
Run E2E tests for worker agent with this change
- Linux
```
====================================================================================================== slowest 5 durations =======================================================================================================
207.05s setup    test/e2e/test_job_submissions.py::TestJobSubmission::test_worker_job_attachments_dep_data_flow_linux[COPIED]
130.06s call     test/e2e/test_job_submissions.py::TestJobSubmission::test_worker_job_attachments_dep_data_flow_linux[COPIED]
6.69s teardown test/e2e/test_job_submissions.py::TestJobSubmission::test_worker_job_attachments_dep_data_flow_linux[COPIED]
==================================================================================== 1 passed, 57 deselected, 1 warning in 343.88s (0:05:43) =====================================================================================
```
- Windows
```
====================================================================================================== slowest 5 durations =======================================================================================================
319.87s setup    test/e2e/test_job_submissions.py::TestJobSubmission::test_worker_job_attachments_dep_data_flow_windows
174.85s call     test/e2e/test_job_submissions.py::TestJobSubmission::test_worker_job_attachments_dep_data_flow_windows
6.69s teardown test/e2e/test_job_submissions.py::TestJobSubmission::test_worker_job_attachments_dep_data_flow_windows
==================================================================================== 1 passed, 57 deselected, 1 warning in 501.49s (0:08:21) =====================================================================================
```

### Was this change documented?
Yes

### Is this a breaking change?
No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*