### PR TITLE
fix: "no latest session action ID" error after job completed

### DIFF
--- a/src/deadline_test_fixtures/deadline/resources.py
+++ b/src/deadline_test_fixtures/deadline/resources.py
@@ -754,22 +754,54 @@ class Job:
         self,
         *,
         deadline_client: DeadlineClient,
+        require_latest_session_action: bool = False,
+        wait_interval_sec: int = 2,
+        max_retries: int = 10,
     ) -> Task:
         """
         Asserts that the job has a single step and a single task, and returns the task.
 
         Args:
             deadline_client (deadline_test_fixtures.client.DeadlineClient): Deadline boto client
+            require_latest_session_action (bool): If True, retry until the task has a latestSessionActionId.
+                This helps handle eventual consistency issues where the task may not yet have the
+                latestSessionActionId field populated even though the job is complete.
+            wait_interval_sec (int): Interval between retries in seconds when require_latest_session_action is True.
+            max_retries (int): Maximum number of retries when require_latest_session_action is True.
         Return:
             task: The single task of the job
         """
-        # Assert there is a single step and task
+
         steps = list(self.list_steps(deadline_client=deadline_client))
         assert len(steps) == 1, "Job contains multiple steps"
         step = steps[0]
-        tasks = list(step.list_tasks(deadline_client=deadline_client))
-        assert len(tasks) == 1, "Job contains multiple tasks"
-        return tasks[0]
+
+        def _get_task():
+            tasks = list(step.list_tasks(deadline_client=deadline_client))
+            assert len(tasks) == 1, "Job contains multiple tasks"
+            return tasks[0]
+
+        if require_latest_session_action:
+            task = None
+
+            def _has_session_action():
+                nonlocal task
+                task = _get_task()
+                return task.latest_session_action_id is not None
+
+            wait_for(
+                description=f"task in job {self.id} to have latestSessionActionId",
+                predicate=_has_session_action,
+                interval_s=wait_interval_sec,
+                max_retries=max_retries,
+            )
+            # This is added to make the type checker happy
+            # If we timed out waiting for the latestSessionActionId, then a TimeoutException
+            # is rasied. Otherwise the task variable is assigned and not None
+            assert task is not None, "Task is None"
+            return task
+        else:
+            return _get_task()
 
     def assert_single_task_log_contains(
         self,
@@ -818,7 +850,9 @@ class Job:
         if isinstance(expected_pattern, str):
             expected_pattern = re.compile(expected_pattern)
 
-        task = self.get_only_task(deadline_client=deadline_client)
+        task = self.get_only_task(
+            deadline_client=deadline_client, require_latest_session_action=True
+        )
 
         session = task.get_last_session(deadline_client=deadline_client)
         session.assert_log_contains(
@@ -867,7 +901,9 @@ class Job:
         if isinstance(expected_pattern, str):
             expected_pattern = re.compile(expected_pattern)
 
-        task = self.get_only_task(deadline_client=deadline_client)
+        task = self.get_only_task(
+            deadline_client=deadline_client, require_latest_session_action=True
+        )
 
         session = task.get_last_session(deadline_client=deadline_client)
         session.assert_log_does_not_contain(

--- a/test/unit/deadline/test_resources.py
+++ b/test/unit/deadline/test_resources.py
@@ -1148,14 +1148,12 @@ class TestJob:
         # GIVEN
         deadline_client = MagicMock()
         logs_client = MagicMock()
-        step = MagicMock()
         task = MagicMock()
-        step.list_tasks.return_value = [task]
         task.get_last_session.return_value = session
         expected_pattern = re.compile(r"a message")
 
         with (
-            patch.object(job, "list_steps", return_value=[step]) as mock_list_steps,
+            patch.object(job, "get_only_task", return_value=task) as mock_get_only_task,
             patch.object(session, "assert_log_contains") as mock_session_assert_log_contains,
         ):
 
@@ -1167,8 +1165,6 @@ class TestJob:
             )
 
         # THEN
-        # This test is only to confirm that no assertion is raised, since the expected message
-        # is in the logs
         mock_session_assert_log_contains.assert_called_once_with(
             logs_client=logs_client,
             expected_pattern=expected_pattern,
@@ -1176,8 +1172,9 @@ class TestJob:
             backoff_factor=datetime.timedelta(milliseconds=300),
             retries=6,
         )
-        mock_list_steps.assert_called_once_with(deadline_client=deadline_client)
-        step.list_tasks.assert_called_once_with(deadline_client=deadline_client)
+        mock_get_only_task.assert_called_once_with(
+            deadline_client=deadline_client, require_latest_session_action=True
+        )
         task.get_last_session.assert_called_once_with(deadline_client=deadline_client)
 
     def test_assert_single_task_log_does_not_contain_success(
@@ -1186,14 +1183,12 @@ class TestJob:
         # GIVEN
         deadline_client = MagicMock()
         logs_client = MagicMock()
-        step = MagicMock()
         task = MagicMock()
-        step.list_tasks.return_value = [task]
         task.get_last_session.return_value = session
         expected_pattern = re.compile(r"a message")
 
         with (
-            patch.object(job, "list_steps", return_value=[step]) as mock_list_steps,
+            patch.object(job, "get_only_task", return_value=task) as mock_get_only_task,
             patch.object(
                 session, "assert_log_does_not_contain"
             ) as mock_session_assert_log_does_not_contain,
@@ -1215,9 +1210,204 @@ class TestJob:
             assert_fail_msg="Expected message found in session log",
             consistency_wait_time=timedelta(seconds=3),
         )
-        mock_list_steps.assert_called_once_with(deadline_client=deadline_client)
-        step.list_tasks.assert_called_once_with(deadline_client=deadline_client)
+        mock_get_only_task.assert_called_once_with(
+            deadline_client=deadline_client, require_latest_session_action=True
+        )
         task.get_last_session.assert_called_once_with(deadline_client=deadline_client)
+
+    def test_get_only_task_with_require_latest_session_action_true(self, job: Job) -> None:
+        """Test that get_only_task retries until task has session action ID."""
+        # GIVEN
+        deadline_client = MagicMock()
+        step = MagicMock()
+
+        # Create tasks: first without session action ID, second with it
+        task_without_session = MagicMock()
+        task_without_session.latest_session_action_id = None
+        task_without_session.id = "task-123"
+
+        task_with_session = MagicMock()
+        task_with_session.latest_session_action_id = (
+            "sessionaction-abcd1234567890abcdef1234567890ab-1"
+        )
+        task_with_session.id = "task-123"
+
+        # First call returns task without session action, second call returns task with it
+        step.list_tasks.side_effect = [[task_without_session], [task_with_session]]
+
+        with patch.object(job, "list_steps", return_value=[step]):
+            # WHEN
+            result = job.get_only_task(
+                deadline_client=deadline_client, require_latest_session_action=True
+            )
+
+            # THEN
+            assert result == task_with_session
+            # In test environment, wait_for_shim calls predicate until it returns True
+            # So we should see multiple calls to list_tasks
+            assert step.list_tasks.call_count >= 2
+
+    def test_get_only_task_with_require_latest_session_action_false(self, job: Job) -> None:
+        """Test that get_only_task works normally when require_latest_session_action=False."""
+        # GIVEN
+        deadline_client = MagicMock()
+        step = MagicMock()
+        task = MagicMock()
+        task.latest_session_action_id = None  # No session action ID
+        task.id = "task-123"
+
+        step.list_tasks.return_value = [task]
+
+        with patch.object(job, "list_steps", return_value=[step]) as mock_list_steps:
+            # WHEN
+            result = job.get_only_task(
+                deadline_client=deadline_client, require_latest_session_action=False
+            )
+
+            # THEN
+            assert result == task
+            # Should only be called once since we don't require session action ID
+            step.list_tasks.assert_called_once_with(deadline_client=deadline_client)
+            mock_list_steps.assert_called_once_with(deadline_client=deadline_client)
+
+    def test_assert_single_task_log_contains_uses_require_latest_session_action(
+        self, job: Job, session: Session
+    ) -> None:
+        """Test that assert_single_task_log_contains uses require_latest_session_action=True."""
+        # GIVEN
+        deadline_client = MagicMock()
+        logs_client = MagicMock()
+        step = MagicMock()
+        expected_pattern = re.compile(r"test pattern")
+
+        # Create tasks: first without session action ID, second with it
+        task_without_session = MagicMock()
+        task_without_session.latest_session_action_id = None
+        task_without_session.get_last_session.return_value = session
+
+        task_with_session = MagicMock()
+        task_with_session.latest_session_action_id = (
+            "sessionaction-abcd1234567890abcdef1234567890ab-1"
+        )
+        task_with_session.get_last_session.return_value = session
+
+        step.list_tasks.side_effect = [[task_without_session], [task_with_session]]
+
+        with (
+            patch.object(job, "list_steps", return_value=[step]),
+            patch.object(session, "assert_log_contains") as mock_session_assert_log_contains,
+        ):
+            # WHEN
+            job.assert_single_task_log_contains(
+                deadline_client=deadline_client,
+                logs_client=logs_client,
+                expected_pattern=expected_pattern,
+            )
+
+            # THEN
+            # Verify retries occurred
+            assert step.list_tasks.call_count >= 2
+            task_with_session.get_last_session.assert_called_once_with(
+                deadline_client=deadline_client
+            )
+            mock_session_assert_log_contains.assert_called_once()
+
+    def test_assert_single_task_log_does_not_contain_uses_require_latest_session_action(
+        self, job: Job, session: Session
+    ) -> None:
+        """Test that assert_single_task_log_does_not_contain uses require_latest_session_action=True."""
+        # GIVEN
+        deadline_client = MagicMock()
+        logs_client = MagicMock()
+        step = MagicMock()
+        expected_pattern = re.compile(r"test pattern")
+
+        # Create tasks: first without session action ID, second with it
+        task_without_session = MagicMock()
+        task_without_session.latest_session_action_id = None
+        task_without_session.get_last_session.return_value = session
+
+        task_with_session = MagicMock()
+        task_with_session.latest_session_action_id = (
+            "sessionaction-abcd1234567890abcdef1234567890ab-1"
+        )
+        task_with_session.get_last_session.return_value = session
+
+        step.list_tasks.side_effect = [[task_without_session], [task_with_session]]
+
+        with (
+            patch.object(job, "list_steps", return_value=[step]),
+            patch.object(
+                session, "assert_log_does_not_contain"
+            ) as mock_session_assert_log_does_not_contain,
+        ):
+            # WHEN
+            job.assert_single_task_log_does_not_contain(
+                deadline_client=deadline_client,
+                logs_client=logs_client,
+                expected_pattern=expected_pattern,
+            )
+
+            # THEN
+            # Verify retries occurred
+            assert step.list_tasks.call_count >= 2
+            task_with_session.get_last_session.assert_called_once_with(
+                deadline_client=deadline_client
+            )
+            mock_session_assert_log_does_not_contain.assert_called_once()
+
+    def test_get_only_task_require_latest_session_action_retry_logic(self, job: Job) -> None:
+        """Test that get_only_task calls wait_for when require_latest_session_action=True and returns the task."""
+        # GIVEN
+        deadline_client = MagicMock()
+        step = MagicMock()
+
+        # Create tasks: first without session action ID, second with it
+        task_without_session = MagicMock()
+        task_without_session.latest_session_action_id = None
+        task_without_session.id = "task-123"
+
+        task_with_session = MagicMock()
+        task_with_session.latest_session_action_id = (
+            "sessionaction-abcd1234567890abcdef1234567890ab-1"
+        )
+        task_with_session.id = "task-123"
+
+        step.list_tasks.side_effect = [[task_without_session], [task_with_session]]
+
+        with (
+            patch.object(job, "list_steps", return_value=[step]),
+            patch.object(mod, "wait_for") as mock_wait_for,
+        ):
+            # Configure wait_for to call the predicate multiple times to simulate retry
+            def wait_for_side_effect(predicate, **kwargs):
+                # Call predicate twice to simulate retry behavior
+                predicate()  # First call returns False (task without session action)
+                predicate()  # Second call returns True (task with session action)
+                return None
+
+            mock_wait_for.side_effect = wait_for_side_effect
+
+            # WHEN
+            result = job.get_only_task(
+                deadline_client=deadline_client, require_latest_session_action=True
+            )
+
+            # THEN
+            # Verify wait_for was called
+            mock_wait_for.assert_called_once()
+
+            # Verify the call had the expected keyword arguments
+            call_kwargs = mock_wait_for.call_args.kwargs
+            assert "description" in call_kwargs
+            assert (
+                f"task in job {job.id} to have latestSessionActionId" in call_kwargs["description"]
+            )
+            assert call_kwargs["interval_s"] == 2
+            assert call_kwargs["max_retries"] == 10
+
+            # Verify the method returns the task with session action ID
+            assert result == task_with_session
 
     def test_list_steps(
         self,


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Deadline Cloud's job APIs are eventually-consistent. There is a common pattern in testing where tests:

1. Submit a job with a single step/task using `Job.submit(...)`
2. Wait for the job to complete (using this library's `Job.wait_until_completed(...)`
3. Assert that a certain pattern is [not] found in the session log for the single task using `Job.assert_single_task_log_contains(...)` and `Job.assert_single_task_log_does_not_contain(...)`

One example is illustrated [here](https://github.com/aws-deadline/deadline-cloud-worker-agent/blob/adec8fcc81d9d7d5dc1c293ed677aba033415e69/test/e2e/test_job_submissions.py#L1610-L1666) the worker agent end-to-end tests.

While `Job.wait_until_complete(...)` may succeed, the subsequent `Job.assert_single_task_log_contains(...)` call may not. This is because the APIs responses are eventually consistent and the `ListTasks` API may not return the task with a populated `latestSessionActionId`.

### What was the solution? (How)

1.  Add additional optional parameters to the `Job.get_only_task()` method:
    *   `require_latest_session_action` (`bool` / defaults to `False`)
    *   `wait_interval_sec` (`wait_interval_sec` / defaults to `2`)
    *    `max_retries` (`int` / defaults to `10`)
    *    When `require_latest_session_action` is `True`, the method will retry based on the configured `wait_interval_sec` and `max_retries` arguments until the task returns a `latestSessionActionId`. If it does not, it raises a `TimeoutError`.
2.  Modify `Job.assert_single_task_log_contains(...)` and `Job.assert_single_task_log_does_not_contain(...)` to pass `require_latest_session_action` as `True` so that these high-level assertion helpers will retry until `latestSessionActionId` is provided from `ListTasks`.

### What is the impact of this change?

*   Tests using the `Job.assert_single_task_log_contains(...)` / `Job.assert_single_task_log_does_not_contain(...)` are less likely to fail due to Deadline Cloud APIs being eventually consistent
*   Tests using `Job.get_single_task(..)` can optionally request retries until the task has a `latestSessionActionId`

### How was this change tested?

I wrote unit tests for the new functionality

I also ran the worker agent E2E test suite using this modified version of `deadline-cloud-test-fixtures` and it passed. A snippet of logs showing the change is using retries:

```log
[2025-10-14 19:10:18,805] [test/e2e/test_override_job_user.py::TestWindowsJobUserOverride::test_env_var_user_override] About to call API (Listing steps for job job-7f81fefdbfd64fef9fb668eed36b5271)
[2025-10-14 19:10:18,805] [test/e2e/test_override_job_user.py::TestWindowsJobUserOverride::test_env_var_user_override] API call succeeded (Listing steps for job job-7f81fefdbfd64fef9fb668eed36b5271)
[2025-10-14 19:10:18,956] [test/e2e/test_override_job_user.py::TestWindowsJobUserOverride::test_env_var_user_override] Waiting for task in job job-7f81fefdbfd64fef9fb668eed36b5271 to have latestSessionActionId
[2025-10-14 19:10:18,956] [test/e2e/test_override_job_user.py::TestWindowsJobUserOverride::test_env_var_user_override] About to call API (Listing steps for job job-7f81fefdbfd64fef9fb668eed36b5271)
[2025-10-14 19:10:18,956] [test/e2e/test_override_job_user.py::TestWindowsJobUserOverride::test_env_var_user_override] API call succeeded (Listing steps for job job-7f81fefdbfd64fef9fb668eed36b5271)
[2025-10-14 19:10:19,292] [test/e2e/test_override_job_user.py::TestWindowsJobUserOverride::test_env_var_user_override] About to call API (Fetching log events for session session-3be8090db57f45b9ba0c844e185a5a4e in log group /aws/deadline/farm-c0fa1a7222424c46989907f824251f23/queue-afc3bccdc64f47a78c1cdcd5626090bc)
[2025-10-14 19:10:19,292] [test/e2e/test_override_job_user.py::TestWindowsJobUserOverride::test_env_var_user_override] API call succeeded (Fetching log events for session session-3be8090db57f45b9ba0c844e185a5a4e in log group /aws/deadline/farm-c0fa1a7222424c46989907f824251f23/queue-afc3bccdc64f47a78c1cdcd5626090bc)
```

Note, I was unable to hit the eventual-consistency reproduction when running the worker agent E2E tests.

### Was this change documented?

The new parameters of `Job.get_only_task()` were added to its docstring

### Is this a breaking change?

No.

*   For `Job.get_only_task(...)`, the new parameters are optional and the previous default behavior was preserved
*   For `Job.assert_single_task_log_contains(...)` / `Job.assert_single_task_log_does_not_contain(...)`, there is a behavioral change, but this only happens when the `ListTasks` API is eventually inconsistent after having called `Job.wait_until_complete(...)` which is rare. Retries of `ListTasks` should be few and can add 20 seconds in the worst case.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*