### PR TITLE
ci: add changelog section for performance improvements

### DIFF
--- a/.semantic_release/CHANGELOG.md.j2
+++ b/.semantic_release/CHANGELOG.md.j2
@@ -8,16 +8,23 @@
         {% endfor %}
     {% endif %}
 
-    {% if "feature" in release["elements"] %}
+    {% if "features" in release["elements"] %}
 ### Features
-        {% for commit in release["elements"]["feature"] %}
+        {% for commit in release["elements"]["features"] %}
 * {% if commit.scope %}**{{ commit.scope }}**: {% endif %}{{ commit.commit.summary[commit.commit.summary.find(": ")+1:].strip() }} ([`{{ commit.short_hash }}`]({{ commit.commit.hexsha | commit_hash_url }}))
         {% endfor %}
     {% endif %}
 
-    {% if "fix" in release["elements"] %}
+    {% if "bug fixes" in release["elements"] %}
 ### Bug Fixes
-        {% for commit in release["elements"]["fix"] %}
+        {% for commit in release["elements"]["bug fixes"] %}
+* {% if commit.scope %}**{{ commit.scope }}**: {% endif %}{{ commit.commit.summary[commit.commit.summary.find(":")+1:].strip() }} ([`{{ commit.short_hash }}`]({{ commit.commit.hexsha | commit_hash_url }}))
+        {% endfor %}
+    {% endif %}
+
+    {% if "performance improvements" in release["elements"] %}
+### Performance Improvements
+        {% for commit in release["elements"]["performance improvements"] %}
 * {% if commit.scope %}**{{ commit.scope }}**: {% endif %}{{ commit.commit.summary[commit.commit.summary.find(":")+1:].strip() }} ([`{{ commit.short_hash }}`]({{ commit.commit.hexsha | commit_hash_url }}))
         {% endfor %}
     {% endif %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,7 @@ show_missing = true
 # Can be removed or set to true once we are v1
 major_on_zero = false
 tag_format = "{version}"
+allow_zero_version = true
 
 [tool.semantic_release.commit_parser_options]
 allowed_tags = [
@@ -178,6 +179,7 @@ patch_tags = [
   "feat",
   "fix",
   "refactor",
+  "perf",
 ]
 
 [tool.semantic_release.publish]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

1.  The version of `python-semantic-release` was bumped in #223, but the new version of `python-semantic-release` included backwards-incompatible changes:
    1.  the major version is bumped by default unless the `allow_zero_version` setting is set to `true`
    2. the sub-keys of the `release["elements"]` jinja context variable have changed since the previously pinned version
3. There is no section in the release process' git history -> changelog template for performance improvements

### What was the solution? (How)

1.  Set the `allow_zero_version` setting in `pyproject.toml` to `true`
2. Modified the keys of `release["elements"]` to correspond to their new values in `python-semantic-release` versions 10.x+
3. Add a section to the changelog template for performance improvements - similar to aws-deadline/deadline-cloud#870. Also add `perf` commits to the `patch_tags` setting of `python-semantic-release` so that they are considered as part of bumping a version for release.

### What is the impact of this change?

1.  The next release of `deadline-cloud-test-fixtures` will bump the patch or minor version instead of the major version.
3.  Developers can use `perf: ...` [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to communicate performance improvements when changelogs are automatically generated as part of the release

### How was this change tested?

1.  Set my local `mainline` branch to this commit
3. Added example commits using the `perf: ...` commit summary message
4. Ran:
    ```
    hatch run release:deps
    hatch run release:bump
    ```
5.  confirmed that rendered `CHANGELOG.md` contained the expected "Performance Improvements" section correctly
6.  confirmed that the patch version was bumped

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*