### PR TITLE
chore(dev): as of hatch 1.16.0, 'hatch build' can't be run in non-builder envs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ __pycache__/
 .vscode
 build
 *_version.py
+.DS_Store
+

--- a/hatch.toml
+++ b/hatch.toml
@@ -23,15 +23,6 @@ lint = [
 [[envs.all.matrix]]
 python = ["3.9", "3.10", "3.11"]
 
-[envs.default.env-vars]
-SKIP_BOOTSTRAP_TEST_RESOURCES="True"
-
-[envs.codebuild.scripts]
-build = "hatch build"
-
-[envs.codebuild.env-vars]
-SKIP_BOOTSTRAP_TEST_RESOURCES="True"
-
 [envs.release]
 detached = true
 

--- a/pipeline/build.sh
+++ b/pipeline/build.sh
@@ -5,6 +5,6 @@ set -e
 pip install --upgrade pip
 pip install --upgrade hatch
 pip install --upgrade twine
-hatch -v run codebuild:lint
-hatch run codebuild:test
-hatch -v run codebuild:build
+hatch -v run lint
+hatch run test
+hatch -v build


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

```
$ hatch run codebuild:build
...
Environment `codebuild` is not a builder environment
```

### What was the solution? (How)

Remove codebuild env since it is no longer needed

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*