### PR TITLE
ci: run code quality checks on feature branch pull requests

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -2,7 +2,7 @@ name: Code Quality
 
 on:
   pull_request:
-    branches: [ mainline, release, 'patch_*' ]
+    branches: [ mainline, release, 'patch_*', "feature_*" ]
   workflow_call:
     inputs:
       branch:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ "mainline" ]
   pull_request:
-    branches: [ "mainline" ]
+    branches: [ "mainline", "feature_*" ]
   schedule:
     - cron: '0 8 * * MON'
 


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The code quality GitHub actions workflow checks are not running on feature branched (`feature_*`). See #238.

### What was the solution? (How)

Modify the GitHub actions workflow to run on pull requests to branch matching the feature branch pattern (`feature_*`).

### What is the impact of this change?

Code quality checks will run when pull requests are opened that target feature branches.

### How was this change tested?

N/A

### Was this change documented?

No

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*