### PR TITLE
chore(deps): update windows python version for worker agent

### DIFF
--- a/src/deadline_test_fixtures/deadline/worker.py
+++ b/src/deadline_test_fixtures/deadline/worker.py
@@ -914,11 +914,11 @@ $successDir="{self.SIGNAL_USER_DATA_DIR}"
 mkdir $successDir -Force
 try {{
     $ProgressPreference = 'SilentlyContinue'
-    Invoke-WebRequest -Uri "https://www.python.org/ftp/python/3.12.10/python-3.12.10-amd64.exe" -OutFile "C:\\python-3.12.10-amd64.exe"
-    $installerHash=(Get-FileHash "C:\\python-3.12.10-amd64.exe" -Algorithm "MD5")
-    $expectedHash="5eddb0b6f12c852725de071ae681dde4"
+    Invoke-WebRequest -Uri "https://www.python.org/ftp/python/3.13.11/python-3.13.11-amd64.exe" -OutFile "C:\\python-3.13.11-amd64.exe"
+    $installerHash=(Get-FileHash "C:\\python-3.13.11-amd64.exe" -Algorithm "MD5")
+    $expectedHash="379a32861f9f0a327f9fa9c163455574"
     if ($installerHash.Hash -ne $expectedHash) {{ throw "Could not verify Python installer." }}
-    Start-Process -FilePath "C:\\python-3.12.10-amd64.exe" -ArgumentList "/quiet InstallAllUsers=1 PrependPath=1 AppendPath=1" -Wait
+    Start-Process -FilePath "C:\\python-3.13.11-amd64.exe" -ArgumentList "/quiet InstallAllUsers=1 PrependPath=1 AppendPath=1" -Wait
     Invoke-WebRequest -Uri "https://awscli.amazonaws.com/AWSCLIV2.msi" -Outfile "C:\\AWSCLIV2.msi"
     Start-Process msiexec.exe -ArgumentList "/i C:\\AWSCLIV2.msi /quiet" -Wait
     $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine")


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Need to update python.

### What was the solution? (How)

They're not making newer python 3.12 executables for windows, so we update to python 3.13

### What is the impact of this change?

newer deps

### How was this change tested?

N/A

### Was this change documented?

N/A

### Is this a breaking change?

N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*