### PR TITLE
chore(deps): update to pytest 9 and black 25.12 + show 3.13/3.14 support

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
     uses: aws-deadline/.github/.github/workflows/reusable_python_build.yml@mainline
     with:
       os: ${{ matrix.os }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Operating System :: POSIX :: Linux",
   "Operating System :: Microsoft :: Windows",
   "Operating System :: MacOS",

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,9 +1,11 @@
 coverage[toml] == 7.*
-pytest == 8.4.*
+pytest == 9.0.*; python_version > "3.9"
+pytest == 8.4.*; python_version <= "3.9"
 pytest-cov == 7.0.*
 pytest-timeout == 2.4.*
 pytest-xdist == 3.8.*
-black == 25.11.*
+black == 25.12.*; python_version > "3.9"
+black == 25.11.*; python_version <= "3.9"
 moto[cloudformation,s3] == 5.1.*
 mypy == 1.19.*
 ruff == 0.14.*


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

Deps dropped 3.9 support and we don't say we work with newer python versions

### What was the solution? (How)

1. Easy enough to support both for now
2. Add actions to run tests with 3.13/3.14 + update docs since users could already pip install on those versions

### What is the impact of this change?

up-to-date deps, accurate docs

### How was this change tested?

```
hatch env prune
hatch run lint
hatch run test
```

### Was this change documented?

N/A

### Is this a breaking change?

N/A

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*