### PR TITLE
feat: provide importable hook for cleaning up leftover JobAttachmentManager queues

### DIFF
--- a/src/deadline_test_fixtures/job_attachment_manager.py
+++ b/src/deadline_test_fixtures/job_attachment_manager.py
@@ -1,21 +1,21 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 from __future__ import annotations
 
-from dataclasses import InitVar, dataclass, field
 import os
+from dataclasses import InitVar, dataclass, field
+from uuid import uuid4
+
 from botocore.client import BaseClient
 from botocore.exceptions import ClientError, WaiterError
 
+from .deadline import Farm, Queue
 from .deadline.client import DeadlineClient
-from .deadline import (
-    Farm,
-    Queue,
-)
+from .models import JobAttachmentSettings
 
-from .models import (
-    JobAttachmentSettings,
-)
-from uuid import uuid4
+# Queue names created by JobAttachmentManager for integration tests.
+# These are used by the orphan cleanup hook in pytest_hooks.py.
+JA_TEST_QUEUE_NAME = "job_attachments_test_queue"
+JA_TEST_QUEUE_NO_SETTINGS_NAME = "job_attachments_test_no_settings_queue"
 
 
 @dataclass
@@ -47,7 +47,7 @@ class JobAttachmentManager:
 
             self.queue = Queue.create(
                 client=self.deadline_client,
-                display_name="job_attachments_test_queue",
+                display_name=JA_TEST_QUEUE_NAME,
                 farm=Farm(self.farm_id),
                 job_attachments=JobAttachmentSettings(
                     bucket_name=self.bucket_name, root_prefix=self.bucket_root_prefix
@@ -55,7 +55,7 @@ class JobAttachmentManager:
             )
             self.queue_with_no_settings = Queue.create(
                 client=self.deadline_client,
-                display_name="job_attachments_test_no_settings_queue",
+                display_name=JA_TEST_QUEUE_NO_SETTINGS_NAME,
                 farm=Farm(self.farm_id),
             )
 

--- a/src/deadline_test_fixtures/pytest_hooks.py
+++ b/src/deadline_test_fixtures/pytest_hooks.py
@@ -1,8 +1,16 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-import logging as _logging
-from typing import Optional as _Optional
+from __future__ import annotations
 
+import logging as _logging
+import os as _os
+from typing import Any as _Any, Optional as _Optional
+
+import boto3 as _boto3
 import pytest as _pytest
+
+from .job_attachment_manager import JA_TEST_QUEUE_NAME, JA_TEST_QUEUE_NO_SETTINGS_NAME
+
+_LOG = _logging.getLogger(__name__)
 
 _root_logger = _logging.getLogger()
 _log_filters: dict[str, _logging.Filter] = {}
@@ -19,11 +27,66 @@ class _PytestIdLoggerFilter(_logging.Filter):
         return True
 
 
+def _cleanup_orphaned_queues(deadline_client: _Any, farm_id: str) -> None:
+    """
+    Clean up orphaned queues that match known test resource patterns.
+
+    This function is best-effort - it logs errors but doesn't raise exceptions
+    to avoid masking actual test failures.
+    """
+    orphan_queue_names = {JA_TEST_QUEUE_NAME, JA_TEST_QUEUE_NO_SETTINGS_NAME}
+
+    try:
+        paginator = deadline_client.get_paginator("list_queues")
+        for page in paginator.paginate(farmId=farm_id):
+            for queue in page.get("queues", []):
+                queue_name = queue.get("displayName", "")
+                queue_id = queue.get("queueId", "")
+
+                if queue_name in orphan_queue_names:
+                    _LOG.warning(
+                        f"Found orphaned test queue: {queue_name} ({queue_id}) - attempting cleanup"
+                    )
+                    try:
+                        deadline_client.delete_queue(farmId=farm_id, queueId=queue_id)
+                        _LOG.info(f"Successfully deleted orphaned queue: {queue_name} ({queue_id})")
+                    except Exception as e:
+                        _LOG.error(
+                            f"Failed to delete orphaned queue {queue_name} ({queue_id}): {e}"
+                        )
+    except Exception as e:
+        _LOG.error(f"Failed to list queues for orphan cleanup: {e}")
+
+
 def pytest_sessionstart(session: _pytest.Session):
     # Base logging configuration
     formatter = _logging.Formatter("[%(asctime)s] %(message)s")
     for handler in _root_logger.handlers:
         handler.setFormatter(formatter)
+
+
+def pytest_sessionfinish(session: _pytest.Session, exitstatus: int) -> None:
+    """
+    Pytest hook that runs at the end of the test session.
+
+    This hook cleans up orphaned test resources (like queues) that may have been
+    left behind due to test crashes or failures. It runs regardless of test outcome.
+    """
+    farm_id = _os.environ.get("FARM_ID")
+    if not farm_id:
+        _LOG.debug("FARM_ID not set, skipping orphan cleanup")
+        return
+
+    _LOG.info("Running orphaned resource cleanup...")
+
+    try:
+        deadline_client = _boto3.client("deadline")
+        _cleanup_orphaned_queues(deadline_client, farm_id)
+    except Exception as e:
+        # Best-effort cleanup - don't fail the session if cleanup fails
+        _LOG.error(f"Orphan cleanup failed: {e}")
+
+    _LOG.info("Orphaned resource cleanup complete")
 
 
 def pytest_runtest_logstart(nodeid: str, location: tuple[str, _Optional[int], str]):


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- When tests with Job Attachment resources crash, the test sometimes orphans left over queues that require operational intervention.

### What was the solution? (How)
- Make sure at the end of the pytest session we have a hook to do a deep clean. 
- Add a pytest hook, pytest_sessionfinish to cleanup.

### What is the impact of this change?
- Better ops handling, this cleanup will make sure test works consistently. 

### How was this change tested?
Crash case with a crash test like the following:  (local test)
Ran the test, and checked AWS Console for deadline cloud. No left over queues are orphaned.

```
@pytest.mark.integ
def test_crash_worker(job_attachment_test: JobAttachmentTest) -> None:
    """
    Causes a segfault, crashing the pytest worker.
    The job_attachment_test fixture uses deploy_job_attachment_resources which creates queues.
    If cleanup works, pytest_sessionfinish should delete the orphaned queues.

    Run manually with: hatch run integ:test -k "test_crash_worker" --runxfail
    """
    import ctypes

    # Cause a segfault by reading from address 0
    ctypes.string_at(0)
```


Normal case to run the job attachments test: 
 hatch run integ:test test/integ/deadline_job_attachments/test_job_attachments.py

```

test/integ/deadline_job_attachments/test_job_attachments.py::test_upload_input_files_all_assets_in_cas[2023-03-03] 
[gw0] [  6%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_upload_input_files_all_assets_in_cas[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_outputs_no_job_attachment_settings_in_job[2023-03-03] 
[gw0] [ 12%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_outputs_no_job_attachment_settings_in_job[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_outputs_no_job_attachment_s3_settings[2023-03-03] 
[gw0] [ 18%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_outputs_no_job_attachment_s3_settings[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_outputs_with_symlink[2023-03-03] 
[gw0] [ 25%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_outputs_with_symlink[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_inputs_with_step_dependencies[2023-03-03] 
[gw0] [ 31%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_inputs_with_step_dependencies[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_with_job_id_step_id_task_id_and_download_directory[2023-03-03] 
[gw0] [ 37%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_with_job_id_step_id_task_id_and_download_directory[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_with_job_id_step_id_and_download_directory[2023-03-03] 
[gw0] [ 43%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_with_job_id_step_id_and_download_directory[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_with_job_id_and_download_directory[2023-03-03] 
[gw0] [ 50%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_with_job_id_and_download_directory[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_upload_input_files_no_download_paths[2023-03-03] 
[gw0] [ 56%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_upload_input_files_no_download_paths[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_inputs_no_inputs[2023-03-03] 
[gw0] [ 62%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_inputs_no_inputs[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_upload_bucket_wrong_account[2023-03-03] 
[gw0] [ 68%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_upload_bucket_wrong_account[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_inputs_bucket_wrong_account[2023-03-03] 
[gw0] [ 75%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_inputs_bucket_wrong_account[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_outputs_bucket_wrong_account[2023-03-03] 
[gw0] [ 81%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_outputs_bucket_wrong_account[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_bucket_wrong_account[2023-03-03] 
[gw0] [ 87%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_bucket_wrong_account[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_no_outputs_dir[2023-03-03] 
[gw0] [ 93%] PASSED test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_no_outputs_dir[2023-03-03] 
test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_windows_long_file_path[2023-03-03] 
[gw0] [100%] SKIPPED test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_windows_long_file_path[2023-03-03] 

========================================================== slowest 5 durations ===========================================================
14.32s teardown test/integ/deadline_job_attachments/test_job_attachments.py::test_download_outputs_windows_long_file_path[2023-03-03]
13.53s setup    test/integ/deadline_job_attachments/test_job_attachments.py::test_upload_input_files_all_assets_in_cas[2023-03-03]
7.03s setup    test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_inputs_with_step_dependencies[2023-03-03]
5.71s call     test/integ/deadline_job_attachments/test_job_attachments.py::test_upload_input_files_all_assets_in_cas[2023-03-03]
3.22s call     test/integ/deadline_job_attachments/test_job_attachments.py::test_sync_inputs_with_step_dependencies[2023-03-03]
================================================ 15 passed, 1 skipped in 74.23s (0:01:14) ================================================
```
### Was this change documented?
- NA, tests only

### Is this a breaking change?
- NA, tests only.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*