### PR TITLE
revert: feat: provide importable hook for cleaning up leftover JobAttachmentManager queues (#256)

### DIFF
--- a/src/deadline_test_fixtures/job_attachment_manager.py
+++ b/src/deadline_test_fixtures/job_attachment_manager.py
@@ -1,21 +1,21 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 from __future__ import annotations
 
-import os
 from dataclasses import InitVar, dataclass, field
-from uuid import uuid4
-
+import os
 from botocore.client import BaseClient
 from botocore.exceptions import ClientError, WaiterError
 
-from .deadline import Farm, Queue
 from .deadline.client import DeadlineClient
-from .models import JobAttachmentSettings
+from .deadline import (
+    Farm,
+    Queue,
+)
 
-# Queue names created by JobAttachmentManager for integration tests.
-# These are used by the orphan cleanup hook in pytest_hooks.py.
-JA_TEST_QUEUE_NAME = "job_attachments_test_queue"
-JA_TEST_QUEUE_NO_SETTINGS_NAME = "job_attachments_test_no_settings_queue"
+from .models import (
+    JobAttachmentSettings,
+)
+from uuid import uuid4
 
 
 @dataclass
@@ -47,7 +47,7 @@ class JobAttachmentManager:
 
             self.queue = Queue.create(
                 client=self.deadline_client,
-                display_name=JA_TEST_QUEUE_NAME,
+                display_name="job_attachments_test_queue",
                 farm=Farm(self.farm_id),
                 job_attachments=JobAttachmentSettings(
                     bucket_name=self.bucket_name, root_prefix=self.bucket_root_prefix
@@ -55,7 +55,7 @@ class JobAttachmentManager:
             )
             self.queue_with_no_settings = Queue.create(
                 client=self.deadline_client,
-                display_name=JA_TEST_QUEUE_NO_SETTINGS_NAME,
+                display_name="job_attachments_test_no_settings_queue",
                 farm=Farm(self.farm_id),
             )
 

--- a/src/deadline_test_fixtures/pytest_hooks.py
+++ b/src/deadline_test_fixtures/pytest_hooks.py
@@ -1,16 +1,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-from __future__ import annotations
-
 import logging as _logging
-import os as _os
-from typing import Any as _Any, Optional as _Optional
+from typing import Optional as _Optional
 
-import boto3 as _boto3
 import pytest as _pytest
-
-from .job_attachment_manager import JA_TEST_QUEUE_NAME, JA_TEST_QUEUE_NO_SETTINGS_NAME
-
-_LOG = _logging.getLogger(__name__)
 
 _root_logger = _logging.getLogger()
 _log_filters: dict[str, _logging.Filter] = {}
@@ -27,66 +19,11 @@ class _PytestIdLoggerFilter(_logging.Filter):
         return True
 
 
-def _cleanup_orphaned_queues(deadline_client: _Any, farm_id: str) -> None:
-    """
-    Clean up orphaned queues that match known test resource patterns.
-
-    This function is best-effort - it logs errors but doesn't raise exceptions
-    to avoid masking actual test failures.
-    """
-    orphan_queue_names = {JA_TEST_QUEUE_NAME, JA_TEST_QUEUE_NO_SETTINGS_NAME}
-
-    try:
-        paginator = deadline_client.get_paginator("list_queues")
-        for page in paginator.paginate(farmId=farm_id):
-            for queue in page.get("queues", []):
-                queue_name = queue.get("displayName", "")
-                queue_id = queue.get("queueId", "")
-
-                if queue_name in orphan_queue_names:
-                    _LOG.warning(
-                        f"Found orphaned test queue: {queue_name} ({queue_id}) - attempting cleanup"
-                    )
-                    try:
-                        deadline_client.delete_queue(farmId=farm_id, queueId=queue_id)
-                        _LOG.info(f"Successfully deleted orphaned queue: {queue_name} ({queue_id})")
-                    except Exception as e:
-                        _LOG.error(
-                            f"Failed to delete orphaned queue {queue_name} ({queue_id}): {e}"
-                        )
-    except Exception as e:
-        _LOG.error(f"Failed to list queues for orphan cleanup: {e}")
-
-
 def pytest_sessionstart(session: _pytest.Session):
     # Base logging configuration
     formatter = _logging.Formatter("[%(asctime)s] %(message)s")
     for handler in _root_logger.handlers:
         handler.setFormatter(formatter)
-
-
-def pytest_sessionfinish(session: _pytest.Session, exitstatus: int) -> None:
-    """
-    Pytest hook that runs at the end of the test session.
-
-    This hook cleans up orphaned test resources (like queues) that may have been
-    left behind due to test crashes or failures. It runs regardless of test outcome.
-    """
-    farm_id = _os.environ.get("FARM_ID")
-    if not farm_id:
-        _LOG.debug("FARM_ID not set, skipping orphan cleanup")
-        return
-
-    _LOG.info("Running orphaned resource cleanup...")
-
-    try:
-        deadline_client = _boto3.client("deadline")
-        _cleanup_orphaned_queues(deadline_client, farm_id)
-    except Exception as e:
-        # Best-effort cleanup - don't fail the session if cleanup fails
-        _LOG.error(f"Orphan cleanup failed: {e}")
-
-    _LOG.info("Orphaned resource cleanup complete")
 
 
 def pytest_runtest_logstart(nodeid: str, location: tuple[str, _Optional[int], str]):


### PR DESCRIPTION
This reverts commit 51c6f9297c58eec1ec180c16bcc0b53fde2f759e.

### What was the problem/requirement? (What/Why)
This commit is causing issues across test runs as the cleanup is only looking at the queue names to determine what to cleanup. If you have multiple CIs running against the same farm they will clobber eachother and cleanup resources that are actively in use.

### What was the solution? (How)
Revert the change and I will be doing a release of 0.18.10 after.

### What is the impact of this change?
Tests won't clobber eachothers runs anymore

### How was this change tested?
It wasn't

### Was this change documented?
It will be in the changelog.

### Is this a breaking change?
Technically it could be and I'm open to making it one if reviewers think it should be.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*