### PR TITLE
ci: remove manual release gate from release publish workflow

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -68,7 +68,6 @@ jobs:
   PublishToPyPI:
     needs: [TagRelease, Publish]
     runs-on: ubuntu-latest
-    environment: release
     permissions:
       id-token: write
     steps:


### PR DESCRIPTION
## Summary
- Removes the `environment: release` declaration from the `PublishToPyPI` job in `.github/workflows/release_publish.yml`, eliminating the manual approval gate that previously blocked PyPI publishes.

## Test plan
- [ ] Verify next release runs end-to-end without requiring environment approval
- [ ] Confirm PyPI publish step still has the OIDC `id-token: write` permission it needs

🤖 Generated with [Claude Code](https://claude.com/claude-code)