### PR TITLE
ci: remove manual test gate from release publish workflow

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -34,15 +34,8 @@ jobs:
     with:
       tag: ${{ needs.TagRelease.outputs.tag }}
 
-  ManualTestGate:
-    needs: [TagRelease, UnitTests]
-    runs-on: ubuntu-latest
-    environment: release-gate
-    steps:
-      - run: echo "Manual testing approved for ${{ needs.TagRelease.outputs.tag }}"
-
   PreRelease:
-      needs: [TagRelease, ManualTestGate]
+      needs: [TagRelease, UnitTests]
       uses: aws-deadline/.github/.github/workflows/reusable_prerelease.yml@mainline
       permissions:
         id-token: write


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The `release_publish.yml` workflow added in #272 includes a `ManualTestGate` job (using the `release-gate` GitHub Environment) between `UnitTests` and `PreRelease`, which blocks releases waiting for manual approval.

### What was the solution? (How)

Removed the `ManualTestGate` job and changed `PreRelease`'s `needs` back to `[TagRelease, UnitTests]`.

### What is the impact of this change?

Releases proceed automatically from `UnitTests` to `PreRelease` without waiting for manual approval on the `release-gate` environment.

### How was this change tested?

Will be validated on the next release run by confirming the workflow proceeds from `UnitTests` to `PreRelease` without an approval prompt.

### Was this change documented?

No — internal CI workflow change only.

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*