### PR TITLE
chore: Schedule weekly Release Bump on Mondays

### DIFF
--- a/.github/workflows/release_bump.yml
+++ b/.github/workflows/release_bump.yml
@@ -1,6 +1,9 @@
 name: "Release: Bump"
 
 on:
+  schedule:
+    # Every Monday at 14:00 UTC (~6/7am Pacific, ~9/10am Eastern).
+    - cron: "0 14 * * 1"
   workflow_dispatch:
     inputs:
       force_version_bump:


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

  The `Release: Bump` workflow in this repo only had a `workflow_dispatch` trigger, which meant every weekly release check required someone to manually kick off the workflow — even on weeks where there were no releasable changes and the bump would produce an empty changelog.

  `aws-deadline/deadline-cloud` already runs its bump workflow on a weekly schedule, so its release cadence is automated. This repo was not on the same cadence.

  ### What was the solution? (How)

  Add a `schedule:` trigger to `.github/workflows/release_bump.yml` that matches `deadline-cloud` exactly: every Monday at 14:00 UTC (`cron: "0 14 * * 1"`). `workflow_dispatch` is preserved so an ad-hoc bump (including a forced patch/minor/major) can still be triggered at any time.

  ### What is the impact of this change?

  - Weeks with no releasable changes are handled automatically — the scheduled run produces an empty changelog PR that can be closed without a release.
  - Weeks with releasable changes get an auto-generated changelog PR on Monday morning, ready to be reviewed and merged.
  - Brings this repo's release cadence in line with `deadline-cloud`.
  - No change to release artifacts, versions, or downstream consumers.

  ### How was this change tested?

  - Verified the cron expression and comment match `aws-deadline/deadline-cloud/.github/workflows/release_bump.yml@mainline` exactly.
  - YAML structure is otherwise unchanged, so the existing `workflow_dispatch` path (with `force_version_bump` choice input) and the call into `aws-deadline/.github/.github/workflows/reusable_bump.yml` are unaffected.
  - Will confirm the first scheduled run appears on the Actions tab next Monday post-merge.

  ### Was this change documented?

  No documentation change required — the existing manual `workflow_dispatch` flow remains supported. The scheduled trigger is a transparent addition.

  ### Is this a breaking change?

  No. Adding a `schedule:` trigger does not affect existing manual invocations or any consumer of the workflow.