### PR TITLE
fix: Ensure tests clean up old job attachment queues.

### DIFF
--- a/src/deadline_test_fixtures/job_attachment_manager.py
+++ b/src/deadline_test_fixtures/job_attachment_manager.py
@@ -1,7 +1,9 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 from __future__ import annotations
 
+import logging
 from dataclasses import InitVar, dataclass, field
+from datetime import datetime, timedelta, timezone
 import os
 from botocore.client import BaseClient
 from botocore.exceptions import ClientError, WaiterError
@@ -16,6 +18,18 @@ from .models import (
     JobAttachmentSettings,
 )
 from uuid import uuid4
+
+LOG = logging.getLogger(__name__)
+
+QUEUE_NAME = "job_attachments_test_queue"
+QUEUE_NAME_NO_SETTINGS = "job_attachments_test_no_settings_queue"
+QUEUE_NAMES = (QUEUE_NAME, QUEUE_NAME_NO_SETTINGS)
+
+# Only delete stale queues older than this. The window is chosen to (a) avoid
+# racing concurrent test runs that share the farm, and (b) leave headroom for
+# test suites whose runtime may grow over time. Tune down only when confident
+# no other process on the farm could be using a same-named queue.
+STALE_QUEUE_MIN_AGE = timedelta(days=1)
 
 
 @dataclass
@@ -39,15 +53,77 @@ class JobAttachmentManager:
         uuid4()
     )  # Set the bucket root prefix for this test run to an UUID to avoid async test execution race conditions
 
+    def _list_all_queues(self) -> list[dict]:
+        """Return every queue in the farm, paginating via nextToken."""
+        queues = []
+        next_token = None
+        while True:
+            kwargs = {"farmId": self.farm_id}
+            if next_token:
+                kwargs["nextToken"] = next_token
+            response = self.deadline_client.list_queues(**kwargs)
+            queues.extend(response.get("queues", []))
+            next_token = response.get("nextToken")
+            if not next_token:
+                return queues
+
+    def _find_stale_queues(self) -> list[dict]:
+        """Return test queues older than STALE_QUEUE_MIN_AGE that are safe to delete.
+
+        Skips queues younger than the cutoff so we don't race with concurrent
+        test runs sharing the farm.
+        """
+        cutoff = datetime.now(timezone.utc) - STALE_QUEUE_MIN_AGE
+        stale = []
+        for queue in self._list_all_queues():
+            if queue["displayName"] not in QUEUE_NAMES:
+                continue
+            if queue["createdAt"] > cutoff:
+                LOG.info(
+                    f"Skipping recent queue {queue['displayName']} ({queue['queueId']}) "
+                    f"createdAt={queue['createdAt']} — may belong to a concurrent test run"
+                )
+                continue
+            stale.append(queue)
+        return stale
+
+    def _delete_queues(self, queues: list[dict]) -> None:
+        """Delete the given queues, swallowing per-queue ClientErrors so one
+        failure does not block the rest."""
+        for queue in queues:
+            queue_id = queue["queueId"]
+            LOG.info(f"Deleting stale queue: {queue['displayName']} ({queue_id})")
+            try:
+                self.deadline_client.delete_queue(farmId=self.farm_id, queueId=queue_id)
+            except ClientError as e:
+                LOG.warning(f"Failed to delete stale queue {queue_id}: {e}")
+            except Exception as e:
+                LOG.warning(f"Unexpected error deleting stale queue {queue_id}: {e}")
+
+    def _cleanup_stale_queues(self) -> None:
+        """Delete pre-existing test queues from previous runs that weren't cleaned
+        up (e.g. timeouts/crashes). Prevents ServiceQuotaExceededException."""
+        LOG.info(f"Checking for stale test queues in farm {self.farm_id}")
+        try:
+            stale_queues = self._find_stale_queues()
+        except ClientError as e:
+            LOG.warning(f"Failed to list queues for stale cleanup: {e}")
+            return
+        except Exception as e:
+            LOG.warning(f"Unexpected error listing queues for stale cleanup: {e}")
+            return
+        self._delete_queues(stale_queues)
+
     def deploy_resources(self):
         """
         Deploy all of the resources needed for job attachment integration tests.
         """
-        try:
+        self._cleanup_stale_queues()
 
+        try:
             self.queue = Queue.create(
                 client=self.deadline_client,
-                display_name="job_attachments_test_queue",
+                display_name=QUEUE_NAME,
                 farm=Farm(self.farm_id),
                 job_attachments=JobAttachmentSettings(
                     bucket_name=self.bucket_name, root_prefix=self.bucket_root_prefix
@@ -55,7 +131,7 @@ class JobAttachmentManager:
             )
             self.queue_with_no_settings = Queue.create(
                 client=self.deadline_client,
-                display_name="job_attachments_test_no_settings_queue",
+                display_name=QUEUE_NAME_NO_SETTINGS,
                 farm=Farm(self.farm_id),
             )
 

--- a/test/unit/test_job_attachment_manager.py
+++ b/test/unit/test_job_attachment_manager.py
@@ -1,5 +1,6 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
+from datetime import datetime, timedelta, timezone
 from typing import Generator
 from unittest.mock import MagicMock, patch
 
@@ -10,6 +11,15 @@ from moto import mock_aws
 
 from deadline_test_fixtures import job_attachment_manager as jam_module
 from deadline_test_fixtures import DeadlineClient, JobAttachmentManager
+
+
+OLD = datetime.now(timezone.utc) - timedelta(days=7)
+# Ten seconds past the 1-day STALE_QUEUE_MIN_AGE cutoff. Hardcoded (not imported
+# from the module) so a regression that loosens the cutoff is caught here. The
+# 10-second margin absorbs any drift between this module-level datetime.now()
+# at import time and the production code's datetime.now() at test execution.
+JUST_STALE = datetime.now(timezone.utc) - timedelta(days=1, seconds=10)
+RECENT = datetime.now(timezone.utc) - timedelta(minutes=5)
 
 
 class TestJobAttachmentManager:
@@ -27,9 +37,11 @@ class TestJobAttachmentManager:
         self,
     ) -> Generator[JobAttachmentManager, None, None]:
         with mock_aws():
+            mock_client = MagicMock()
+            mock_client.list_queues.return_value = {"queues": []}
             yield JobAttachmentManager(
                 s3_client=boto3.client("s3"),
-                deadline_client=DeadlineClient(MagicMock()),
+                deadline_client=DeadlineClient(mock_client),
                 stage="test",
                 account_id="123456789101",
                 farm_id="farm-123450981092384",
@@ -49,7 +61,7 @@ class TestJobAttachmentManager:
             job_attachment_manager.deploy_resources()
 
             # THEN
-            mock_queue_cls.create.call_count == 2
+            assert mock_queue_cls.create.call_count == 2
 
         @pytest.mark.parametrize(
             "error",
@@ -179,4 +191,229 @@ class TestJobAttachmentManager:
 
         # THEN
         spy_empty_bucket.assert_called_once()
-        mock_queue_cls.create.return_value.delete.call_count == 2
+        assert mock_queue_cls.create.return_value.delete.call_count == 2
+
+    class TestCleanupStaleQueues:
+        def test_deletes_queues_with_matching_names(
+            self,
+            job_attachment_manager: JobAttachmentManager,
+        ):
+            """
+            Test that stale queues with matching display names are deleted.
+            """
+            # GIVEN
+            mock_client = job_attachment_manager.deadline_client._real_client
+            mock_client.list_queues.return_value = {
+                "queues": [
+                    {
+                        "queueId": "queue-stale1",
+                        "displayName": "job_attachments_test_queue",
+                        "createdAt": OLD,
+                    },
+                    {
+                        "queueId": "queue-stale2",
+                        "displayName": "job_attachments_test_no_settings_queue",
+                        "createdAt": OLD,
+                    },
+                    {
+                        "queueId": "queue-keep",
+                        "displayName": "some_other_queue",
+                        "createdAt": OLD,
+                    },
+                ]
+            }
+
+            # WHEN
+            job_attachment_manager._cleanup_stale_queues()
+
+            # THEN
+            assert mock_client.delete_queue.call_count == 2
+            mock_client.delete_queue.assert_any_call(
+                farmId=job_attachment_manager.farm_id, queueId="queue-stale1"
+            )
+            mock_client.delete_queue.assert_any_call(
+                farmId=job_attachment_manager.farm_id, queueId="queue-stale2"
+            )
+
+        def test_deletes_queue_just_past_cutoff(
+            self,
+            job_attachment_manager: JobAttachmentManager,
+        ):
+            """
+            A queue created just past STALE_QUEUE_MIN_AGE must be deleted —
+            exercises the cutoff lower bound (counterpart to test_skips_recent_queues).
+            """
+            # GIVEN
+            mock_client = job_attachment_manager.deadline_client._real_client
+            mock_client.list_queues.return_value = {
+                "queues": [
+                    {
+                        "queueId": "queue-just-stale",
+                        "displayName": "job_attachments_test_queue",
+                        "createdAt": JUST_STALE,
+                    },
+                ]
+            }
+
+            # WHEN
+            job_attachment_manager._cleanup_stale_queues()
+
+            # THEN
+            mock_client.delete_queue.assert_called_once_with(
+                farmId=job_attachment_manager.farm_id, queueId="queue-just-stale"
+            )
+
+        def test_skips_recent_queues(
+            self,
+            job_attachment_manager: JobAttachmentManager,
+        ):
+            """
+            Recent queues (within STALE_QUEUE_MIN_AGE) must not be deleted — they
+            may belong to a concurrently-running test process sharing the farm.
+            """
+            # GIVEN
+            mock_client = job_attachment_manager.deadline_client._real_client
+            mock_client.list_queues.return_value = {
+                "queues": [
+                    {
+                        "queueId": "queue-old",
+                        "displayName": "job_attachments_test_queue",
+                        "createdAt": OLD,
+                    },
+                    {
+                        "queueId": "queue-recent",
+                        "displayName": "job_attachments_test_queue",
+                        "createdAt": RECENT,
+                    },
+                ]
+            }
+
+            # WHEN
+            job_attachment_manager._cleanup_stale_queues()
+
+            # THEN — only the old queue is deleted; recent + missing-timestamp are skipped
+            mock_client.delete_queue.assert_called_once_with(
+                farmId=job_attachment_manager.farm_id, queueId="queue-old"
+            )
+
+        def test_handles_list_queues_error_gracefully(
+            self,
+            job_attachment_manager: JobAttachmentManager,
+        ):
+            """
+            Test that errors during stale queue cleanup don't block test execution.
+            """
+            # GIVEN
+            mock_client = job_attachment_manager.deadline_client._real_client
+            mock_client.list_queues.side_effect = ClientError(
+                {"Error": {"Code": "AccessDeniedException", "Message": "Access denied"}},
+                "ListQueues",
+            )
+
+            # WHEN / THEN - should not raise
+            job_attachment_manager._cleanup_stale_queues()
+
+        def test_paginates_through_all_queues(
+            self,
+            job_attachment_manager: JobAttachmentManager,
+        ):
+            """
+            Test that stale queue cleanup follows nextToken across multiple pages.
+            """
+            # GIVEN
+            mock_client = job_attachment_manager.deadline_client._real_client
+            mock_client.list_queues.side_effect = [
+                {
+                    "queues": [
+                        {
+                            "queueId": "queue-page1",
+                            "displayName": "job_attachments_test_queue",
+                            "createdAt": OLD,
+                        },
+                    ],
+                    "nextToken": "token-1",
+                },
+                {
+                    "queues": [
+                        {
+                            "queueId": "queue-page2",
+                            "displayName": "job_attachments_test_no_settings_queue",
+                            "createdAt": OLD,
+                        },
+                    ],
+                },
+            ]
+
+            # WHEN
+            job_attachment_manager._cleanup_stale_queues()
+
+            # THEN
+            assert mock_client.list_queues.call_count == 2
+            mock_client.list_queues.assert_any_call(
+                farmId=job_attachment_manager.farm_id, nextToken="token-1"
+            )
+            assert mock_client.delete_queue.call_count == 2
+            mock_client.delete_queue.assert_any_call(
+                farmId=job_attachment_manager.farm_id, queueId="queue-page1"
+            )
+            mock_client.delete_queue.assert_any_call(
+                farmId=job_attachment_manager.farm_id, queueId="queue-page2"
+            )
+
+        def test_handles_delete_queue_error_gracefully(
+            self,
+            job_attachment_manager: JobAttachmentManager,
+        ):
+            """
+            Test that a failure to delete one stale queue doesn't prevent others from being deleted.
+            """
+            # GIVEN
+            mock_client = job_attachment_manager.deadline_client._real_client
+            mock_client.list_queues.return_value = {
+                "queues": [
+                    {
+                        "queueId": "queue-stale1",
+                        "displayName": "job_attachments_test_queue",
+                        "createdAt": OLD,
+                    },
+                    {
+                        "queueId": "queue-stale2",
+                        "displayName": "job_attachments_test_no_settings_queue",
+                        "createdAt": OLD,
+                    },
+                ]
+            }
+            mock_client.delete_queue.side_effect = [
+                ClientError(
+                    {"Error": {"Code": "ConflictException", "Message": "Queue in use"}},
+                    "DeleteQueue",
+                ),
+                None,  # Second delete succeeds
+            ]
+
+            # WHEN / THEN - should not raise
+            job_attachment_manager._cleanup_stale_queues()
+            assert mock_client.delete_queue.call_count == 2
+
+        def test_no_matching_queues_does_nothing(
+            self,
+            job_attachment_manager: JobAttachmentManager,
+        ):
+            """If no queues match our display names, nothing is deleted."""
+            # GIVEN
+            mock_client = job_attachment_manager.deadline_client._real_client
+            mock_client.list_queues.return_value = {
+                "queues": [
+                    {
+                        "queueId": "queue-other",
+                        "displayName": "some_other_queue",
+                        "createdAt": OLD,
+                    },
+                ]
+            }
+
+            # WHEN
+            job_attachment_manager._cleanup_stale_queues()
+
+            # THEN
+            mock_client.delete_queue.assert_not_called()


### PR DESCRIPTION
## What was the problem/requirement? (What/Why)

Job attachment integration tests create two queues per run (`job_attachments_test_queue` and `job_attachments_test_no_settings_queue`) and clean them up at teardown. When a test run crashes, times out, or is killed mid-flight, those queues leak. Over time the farm accumulates orphaned queues until the per-farm queue quota is hit, and subsequent runs fail with `ServiceQuotaExceededException` during `Queue.create`.

## What was the solution? (How)

Before deploying resources, `JobAttachmentManager.deploy_resources()` now opportunistically deletes pre-existing test queues that match our display names and are older than `STALE_QUEUE_MIN_AGE` (1 day). The age cutoff prevents disrupting concurrently-running test processes that share the farm and leaves headroom for test suites whose runtime may grow. Cleanup is best-effort: any failure (list, delete, or unexpected error) is logged at warning level and execution continues, so a transient AWS error during cleanup never blocks the test run itself.

New helpers added:
- `_list_all_queues()` — paginates `ListQueues` via `nextToken`.
- `_find_stale_queues()` — filters by display name and `createdAt` cutoff.
- `_delete_queues()` — deletes the given queues, swallowing per-queue errors.
- `_cleanup_stale_queues()` — orchestrates the above; called at the start of `deploy_resources()`.

## What is the impact of this change?

- Eliminates a recurring class of test failures caused by leaked queues from prior runs.
- Adds two `ListQueues` (paginated) and up to N `DeleteQueue` calls at the start of each `deploy_resources()` invocation. In steady state with no leaks, this is one `ListQueues` call.
- Safe for concurrent runs sharing a farm: queues younger than 1 day are never deleted.

## How was this change tested?

New unit tests in `TestCleanupStaleQueues` cover:
- Deletion of queues with matching display names; non-matching names skipped.
- Boundary just past the cutoff (`JUST_STALE`, 10 s past `STALE_QUEUE_MIN_AGE`) — deleted.
- Recent queues (within the cutoff) — skipped.
- No matching queues — no-op.
- Pagination across multiple `ListQueues` pages.
- Graceful handling of `ListQueues` and `DeleteQueue` `ClientError`s.

Also fixed two pre-existing assertions in this file that were missing the `assert` keyword (`mock_queue_cls.create.call_count == 2` was a no-op expression).

All unit tests pass; ruff, black, and mypy clean.

## Was this change documented?

No public-facing documentation change. New helpers have docstrings and the module-level `STALE_QUEUE_MIN_AGE` constant has an inline comment explaining the rationale and tuning constraints.

## Is this a breaking change?

No. The new behavior is internal to `JobAttachmentManager.deploy_resources()` and runs before the existing queue-creation logic. Public API is unchanged.
