### PR TITLE
fix: increase Windows configure SSM timeout from 4 to 8 minutes

### DIFF
--- a/src/deadline_test_fixtures/deadline/worker.py
+++ b/src/deadline_test_fixtures/deadline/worker.py
@@ -694,7 +694,7 @@ class WindowsInstanceWorkerBase(EC2InstanceWorker):
 
         cmd_result = self.send_command(
             f"{self.configure_worker_command(config=self.configuration)}",
-            {"Delay": 5, "MaxAttempts": 48},
+            {"Delay": 5, "MaxAttempts": 96},
         )
         assert cmd_result.exit_code == 0, f"Failed to configure Worker agent: {cmd_result}"
         LOG.info("Successfully configured Worker agent")


### PR DESCRIPTION
The SSM waiter for the Windows configure command (pip install + install-deadline-worker + Start-Service) was set to 4 minutes (Delay=5s, MaxAttempts=48). When pip install takes longer than usual due to network variability, there's insufficient time left for Start-Service to complete, causing spurious test failures.

Double the budget to 8 minutes (MaxAttempts=96) to accommodate variable pip install times while still failing reasonably fast on genuine issues.

### What was the problem/requirement? (What/Why)

### What was the solution? (How)

### What is the impact of this change?

### How was this change tested?

### Was this change documented?

### Is this a breaking change?

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*