### PR TITLE
fix: retry configure command once, if it fails

### DIFF
--- a/src/deadline_test_fixtures/deadline/worker.py
+++ b/src/deadline_test_fixtures/deadline/worker.py
@@ -692,10 +692,13 @@ class WindowsInstanceWorkerBase(EC2InstanceWorker):
         assert self.instance_id
         LOG.info(f"Sending SSM command to configure Worker agent on instance {self.instance_id}")
 
-        cmd_result = self.send_command(
-            f"{self.configure_worker_command(config=self.configuration)}",
-            {"Delay": 5, "MaxAttempts": 48},
-        )
+        configure_cmd = self.configure_worker_command(config=self.configuration)
+        cmd_result = self.send_command(configure_cmd, {"Delay": 5, "MaxAttempts": 48})
+
+        if cmd_result.exit_code == -1:
+            LOG.warning(f"Configure command was not delivered to {self.instance_id}, retrying...")
+            cmd_result = self.send_command(configure_cmd, {"Delay": 5, "MaxAttempts": 48})
+
         assert cmd_result.exit_code == 0, f"Failed to configure Worker agent: {cmd_result}"
         LOG.info("Successfully configured Worker agent")
 


### PR DESCRIPTION
 ### What was the problem/requirement? (What/Why)

Windows worker agent e2e tests are failing intermittently during startup. The SSM command to configure the worker agent (`_setup_worker_agent`) occasionally hits a transient SSM delivery gap — the command is reported as `InProgress` but never executes on the instance. After the 4-minute waiter timeout, `get_command_invocation` returns `exit_code: -1` with empty stdout/stderr, and the test fails.

  Investigation of confirmed the configure command was never delivered to instance `i-0536c007e39f21681`. A subsequent SSM command to the same instance succeeded 4 minutes later,
  confirming the SSM agent was healthy — the command just fell into a brief delivery gap after the preceding userdata check. A successful configure command only takes ~1m35s.

  ### What was the solution? (How)

  Added a retry of the configure worker SSM command in `WindowsInstanceWorkerBase._setup_worker_agent()`. If the first attempt returns `exit_code == -1` (command not delivered/executed), it immediately retries with
  the same 4-minute timeout.

  ### What is the impact of this change?

  Reduces intermittent Windows e2e test failures caused by transient SSM command delivery issues. In the worst case (two delivery failures), the test takes 8 minutes instead of 4 before failing.

  ### How was this change tested?

  - Investigated the failing SSM command and confirmed `Undeliverable` status with empty stdout (nothing ran)
  - Verified a successful configure command completes in ~1m35s, well within the 4-minute timeout
  - Confirmed `install-deadline-worker` is idempotent — handles existing users (`check_account_existence` before `create_local_agent_user`), existing groups (`check_account_existence` before
  `create_local_queue_user_group`), and existing services (`ERROR_SERVICE_EXISTS` → update)

  ### Was this change documented?

N/a

  ### Is this a breaking change?

N/A

  ----

  *By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*