### PR TITLE
chore: add timing instrumentation to worker bootstrap

### DIFF
--- a/src/deadline_test_fixtures/deadline/worker.py
+++ b/src/deadline_test_fixtures/deadline/worker.py
@@ -1113,11 +1113,15 @@ class PosixInstanceBuildWorker(PosixInstanceWorkerBase):
         """Get the command to configure the Worker. This must be run as root."""
         cmds = [
             "set -x",
+            'T0=$(date +%s); echo "TIMING: bootstrap_start=$(date -Iseconds)"',
             "source /opt/deadline/worker/bin/activate",
             f"AWS_DEFAULT_REGION={self.configuration.region}",
+            'echo "TIMING: pip_install_start elapsed=$(($(date +%s) - T0))s"',
             config.worker_agent_install.install_command_for_linux,
+            'echo "TIMING: pip_install_done elapsed=$(($(date +%s) - T0))s"',
             *(config.pre_install_commands or []),
             # fmt: off
+            "echo \"TIMING: configure_worker_start elapsed=$(($(date +%s) - T0))s\"",
             (
                 "install-deadline-worker "
                 + "-y "
@@ -1135,6 +1139,7 @@ class PosixInstanceBuildWorker(PosixInstanceWorkerBase):
                     else ""
                 )
             ),
+            "echo \"TIMING: configure_worker_done elapsed=$(($(date +%s) - T0))s\"",
             # fmt: on
             f"runuser --login {self.configuration.agent_user} --command 'echo \"source /opt/deadline/worker/bin/activate\" >> $HOME/.bashrc'",
         ]


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

When worker bootstrap fails (e.g. CodeArtifact 504 during pip install), the only error is `Failed to configure Worker agent: exit_code: 1`. Oncall has to dig through verbose SSM output to identify which step failed and how far bootstrap got before dying.

### What was the solution? (How)

Added `TIMING:` echo statements between key bootstrap steps in `configure_worker_command()`. The first line logs an ISO timestamp (when bootstrap started), subsequent lines log elapsed seconds since start. When bootstrap fails, the last TIMING line shows exactly which step was running.

### What is the impact of this change?

5 extra lines in SSM command output per worker launch. No behavioral change.

### How was this change tested?

This is a logging-only addition to shell commands joined by `&&`. No behavioral change to verify.

### Was this change documented?

No documentation needed.

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*