### PR TITLE
chore(deps): Update moto, pytest, black and mypy deps

### DIFF
--- a/.github/scripts/get_latest_changelog.py
+++ b/.github/scripts/get_latest_changelog.py
@@ -29,6 +29,7 @@ Running this script on the above CHANGELOG.md should return the following conten
 
 ```
 """
+
 import re
 
 h2 = r"^##\s.*$"

--- a/hatch_version_hook.py
+++ b/hatch_version_hook.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 from typing import Any, Optional
 
-
 _logger = logging.Logger(__name__, logging.INFO)
 _stdout_handler = logging.StreamHandler(sys.stdout)
 _stdout_handler.addFilter(lambda record: record.levelno <= logging.INFO)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,7 @@ known-first-party = [
 
 [tool.black]
 line-length = 100
+target-version = ["py39", "py310", "py311", "py312", "py313"]
 
 [tool.pytest.ini_options]
 xfail_strict = true

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,12 +1,14 @@
 coverage[toml] == 7.*
-pytest == 9.0.*; python_version > "3.9"
+pytest == 9.1.*; python_version > "3.9"
 pytest == 8.4.*; python_version <= "3.9"
 pytest-cov == 7.1.*
 pytest-timeout == 2.4.*
 pytest-xdist == 3.8.*
-black == 25.11.*; python_version > "3.9"
+black == 26.5.*; python_version > "3.9"
 black == 25.11.*; python_version <= "3.9"
-moto[cloudformation,s3] == 5.1.*
-mypy == 1.19.*
+moto[cloudformation,s3] == 5.2.*; python_version > "3.9"
+moto[cloudformation,s3] == 5.1.*; python_version <= "3.9"
+mypy == 2.1.*; python_version > "3.9"
+mypy == 1.19.*; python_version <= "3.9"
 ruff == 0.15.*
 twine == 6.2.*

--- a/src/deadline_test_fixtures/util.py
+++ b/src/deadline_test_fixtures/util.py
@@ -8,7 +8,6 @@ from time import sleep
 from typing import Any, Callable
 import functools
 
-
 LOG = logging.getLogger(__name__)
 
 

--- a/test/unit/test_job_attachment_manager.py
+++ b/test/unit/test_job_attachment_manager.py
@@ -12,7 +12,6 @@ from moto import mock_aws
 from deadline_test_fixtures import job_attachment_manager as jam_module
 from deadline_test_fixtures import DeadlineClient, JobAttachmentManager
 
-
 OLD = datetime.now(timezone.utc) - timedelta(days=7)
 # Ten seconds past the 1-day STALE_QUEUE_MIN_AGE cutoff. Hardcoded (not imported
 # from the module) so a regression that loosens the cutoff is caught here. The


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

We had a few deps that needed to be updated. 

- https://github.com/aws-deadline/deadline-cloud-test-fixtures/pull/286
- https://github.com/aws-deadline/deadline-cloud-test-fixtures/pull/287
- https://github.com/aws-deadline/deadline-cloud-test-fixtures/pull/288
- https://github.com/aws-deadline/deadline-cloud-test-fixtures/pull/289


### What was the solution? (How)


But all of them required Python versions above 3.9. Hence, made the updates conditional based on the python version it is running on. 

### What is the impact of this change?

Updated dependencies. 

### Was this change documented?

Just deps change, no doc necessary. 

### Is this a breaking change?

No

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*