### PR TITLE
feat: Add the test fixtures for GUI testing using xa11y.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,66 @@ def test_something(double_worker: DoubleWorker) -> None:
     # etc.
 ```
 
+## DCC UI Test Components
+
+The standard package installation includes the dependencies needed to test a
+graphical submitter:
+
+```sh
+pip install deadline-cloud-test-fixtures
+```
+
+The package provides four independent building blocks:
+
+- `deadline_test_fixtures.deadline_mock`: an observable, scenario-driven
+  Deadline REST-JSON server. `MockDeadlineServerProcess` runs it outside the
+  pytest process so native accessibility waits cannot starve the server thread.
+- `deadline_test_fixtures.xa11y`: cross-platform accessibility application
+  discovery and reusable widget controls.
+- `deadline_test_fixtures.job_bundle`: conventional case directories and
+  structural bundle comparison with configurable normalization.
+- `deadline_test_fixtures.images`: render comparison by dimensions and pixel
+  tolerance.
+
+Each DCC remains responsible for launching its host application and opening its
+plugin. A typical offline test setup is:
+
+```py
+import os
+
+from deadline_test_fixtures.deadline_mock import (
+    MockDeadlineServerProcess,
+    build_mock_environment,
+    write_deadline_config,
+)
+
+with MockDeadlineServerProcess() as server:
+    backend = server.backend
+    assert backend is not None and server.base_url is not None
+    write_deadline_config(
+        tmp_path / "deadline.config",
+        farm_id=backend.farm_id,
+        queue_id=backend.queue_id,
+        job_history_dir=tmp_path / "job_history",
+    )
+    env = build_mock_environment(
+        os.environ,
+        deadline_endpoint_url=server.base_url,
+        config_path=tmp_path / "deadline.config",
+        home_dir=tmp_path / "home",
+    )
+    # Launch the DCC with env, then locate its accessibility application.
+```
+
+`find_accessibility_app` locates a DCC host or submitter dialog by process ID
+and an optional application-name prefix. Each DCC remains responsible for
+launching, monitoring, and terminating its host process.
+
+Deadline's service model injects a `management.` host prefix. A DCC subprocess
+must disable that injection or redirect `management.*` to loopback; the default
+`DEADLINE_CLOUD_MOCK_MODE=1` environment marker is provided for a test sidecar
+to enable that behavior.
+
 ## Telemetry
 
 This library collects telemetry data by default. Telemetry events contain non-personally-identifiable information that helps us understand how users interact with our software so we know what features our customers use, and/or what existing pain points are.
@@ -144,4 +204,3 @@ See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more inform
 ## License
 
 This project is licensed under the Apache-2.0 License.
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,12 @@ dependencies = [
   # transitively then resolving the dependency closure of this package in conjunction with
   # other test dependencies in other packages can result in it taking 20+ minutes to resolve
   # dependencies in Python3.9. So, we explicitly include the botocore dependency here.
-  "botocore >= 1.34.75"
+  "botocore >= 1.34.75",
+  "xa11y >= 0.9.1",
+  "PyYAML >= 6.0",
+  "numpy >= 1.23",
+  "Pillow >= 10.0",
+  "openjd-cli >= 0.7",
 ]
 
 [project.urls]

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -10,5 +10,6 @@ moto[cloudformation,s3] == 5.2.*; python_version > "3.9"
 moto[cloudformation,s3] == 5.1.*; python_version <= "3.9"
 mypy == 2.1.*; python_version > "3.9"
 mypy == 1.19.*; python_version <= "3.9"
+types-PyYAML == 6.*
 ruff == 0.15.*
 twine == 6.2.*

--- a/src/deadline_test_fixtures/deadline_mock/__init__.py
+++ b/src/deadline_test_fixtures/deadline_mock/__init__.py
@@ -1,0 +1,27 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Hermetic Deadline Cloud service fixtures."""
+
+from .backend import (
+    ADMIN_RESET_PATH,
+    ADMIN_STATE_PATH,
+    MockDeadlineBackend,
+    route,
+    start_server,
+)
+from .config import build_mock_environment, write_deadline_config
+from .process import MockDeadlineServerProcess, RemoteDeadlineBackend
+from .scenario import MockDeadlineScenario
+
+__all__ = [
+    "ADMIN_RESET_PATH",
+    "ADMIN_STATE_PATH",
+    "MockDeadlineBackend",
+    "MockDeadlineScenario",
+    "MockDeadlineServerProcess",
+    "RemoteDeadlineBackend",
+    "build_mock_environment",
+    "route",
+    "start_server",
+    "write_deadline_config",
+]

--- a/src/deadline_test_fixtures/deadline_mock/_server_child.py
+++ b/src/deadline_test_fixtures/deadline_mock/_server_child.py
@@ -1,0 +1,36 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Child-process entry point for :class:`MockDeadlineServerProcess`."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+from .backend import MockDeadlineBackend, start_server
+from .process import _SCENARIO_ENV
+from .scenario import MockDeadlineScenario
+
+
+def main() -> None:
+    serialized = os.environ.get(_SCENARIO_ENV)
+    scenario = (
+        MockDeadlineScenario.from_dict(json.loads(serialized))
+        if serialized
+        else MockDeadlineScenario()
+    )
+    backend = MockDeadlineBackend(scenario)
+    backend.log_callback = lambda message: print(
+        f"[mock-deadline] {message}", file=sys.stderr, flush=True
+    )
+    server, base_url, thread = start_server(backend)
+    print(base_url, flush=True)
+    try:
+        thread.join()
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/deadline_test_fixtures/deadline_mock/backend.py
+++ b/src/deadline_test_fixtures/deadline_mock/backend.py
@@ -1,0 +1,414 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Observable HTTP mock for Deadline submitter tests."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import threading
+import time
+import traceback
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Callable, Optional
+from urllib.parse import parse_qs, urlparse
+
+import botocore.session
+from botocore.exceptions import ClientError
+from botocore.model import ServiceModel
+from botocore.validate import ParamValidator
+
+from .scenario import MockDeadlineScenario
+
+API_PREFIX = "/2023-10-12"
+ADMIN_STATE_PATH = "/__deadline_test_fixtures__/state"
+ADMIN_RESET_PATH = "/__deadline_test_fixtures__/reset"
+
+_INT_QUERY_PARAMS = {"maxResults", "itemOffset", "pageSize"}
+_MAX_BODY_BYTES = 10 * 1024 * 1024
+
+
+def route(method: str, path: str, operation: str) -> Callable:
+    """Associate a backend method with a Deadline REST-JSON route."""
+
+    def decorator(function: Callable) -> Callable:
+        setattr(function, "__http_route__", (method, f"{API_PREFIX}{path}", operation))
+        return function
+
+    return decorator
+
+
+def _resource_not_found(resource_type: str, resource_id: str, operation: str) -> ClientError:
+    return ClientError(
+        {
+            "Error": {
+                "Code": "ResourceNotFoundException",
+                "Message": (
+                    f"Resource of type {resource_type} with id {resource_id} does not exist."
+                ),
+            }
+        },
+        operation,
+    )
+
+
+class MockDeadlineBackend:
+    """In-memory resources and observability for the mock service."""
+
+    def __init__(
+        self,
+        scenario: Optional[MockDeadlineScenario] = None,
+        *,
+        validate_responses: bool = True,
+    ) -> None:
+        self.scenario = scenario or MockDeadlineScenario()
+        self.validate_responses = validate_responses
+        self.response_delay_s = self.scenario.response_delay_s
+        self._lock = threading.Lock()
+        self.log_callback: Optional[Callable[[str], None]] = None
+        self.farms: dict[str, dict[str, Any]] = {}
+        self.queues: dict[tuple[str, str], dict[str, Any]] = {}
+        self.queue_environments: dict[tuple[str, str], list[dict[str, Any]]] = {}
+        self.storage_profiles: dict[tuple[str, str], list[dict[str, Any]]] = {}
+        self.call_counts: dict[str, int] = {}
+        self.request_log: list[tuple[str, str, str]] = []
+        self.unmatched_requests: list[tuple[str, str]] = []
+        self.scenario.seed(self)
+
+    @property
+    def farm_id(self) -> str:
+        return self.scenario.farm_id
+
+    @property
+    def queue_id(self) -> str:
+        return self.scenario.queue_id
+
+    def reset(self) -> None:
+        """Restore scenario resources and clear request observability."""
+        with self._lock:
+            self.call_counts.clear()
+            self.request_log.clear()
+            self.unmatched_requests.clear()
+            self.scenario.seed(self)
+
+    def snapshot(self) -> dict[str, Any]:
+        """Return JSON-serializable state for remote assertions."""
+        with self._lock:
+            return {
+                "identifiers": {
+                    "farm_id": self.farm_id,
+                    "queue_id": self.queue_id,
+                },
+                "call_counts": dict(self.call_counts),
+                "request_log": [list(request) for request in self.request_log],
+                "unmatched_requests": [list(request) for request in self.unmatched_requests],
+                "resources": {
+                    "farms": list(self.farms.values()),
+                    "queues": list(self.queues.values()),
+                    "queue_environments": [
+                        environment
+                        for environments in self.queue_environments.values()
+                        for environment in environments
+                    ],
+                    "storage_profiles": [
+                        profile
+                        for profiles in self.storage_profiles.values()
+                        for profile in profiles
+                    ],
+                },
+            }
+
+    def _log(self, message: str) -> None:
+        if self.log_callback is not None:
+            try:
+                self.log_callback(message)
+            except Exception:
+                # Observability is best-effort and must not break request handling.
+                pass
+
+    def _queue_key(self, farm_id: str, queue_id: str, operation: str) -> tuple[str, str]:
+        key = (farm_id, queue_id)
+        if key not in self.queues:
+            raise _resource_not_found("queue", queue_id, operation)
+        return key
+
+    @route("GET", "/farms", "ListFarms")
+    def list_farms(self, **kwargs: Any) -> dict[str, Any]:
+        return {"farms": list(self.farms.values())}
+
+    @route("GET", "/farms/{farmId}", "GetFarm")
+    def get_farm(self, *, farmId: str) -> dict[str, Any]:
+        try:
+            return dict(self.farms[farmId])
+        except KeyError:
+            raise _resource_not_found("farm", farmId, "GetFarm")
+
+    @route("GET", "/farms/{farmId}/queues", "ListQueues")
+    def list_queues(self, *, farmId: str, **kwargs: Any) -> dict[str, Any]:
+        if farmId not in self.farms:
+            raise _resource_not_found("farm", farmId, "ListQueues")
+        return {
+            "queues": [
+                queue
+                for (candidate_farm, _), queue in self.queues.items()
+                if candidate_farm == farmId
+            ]
+        }
+
+    @route("GET", "/farms/{farmId}/queues/{queueId}", "GetQueue")
+    def get_queue(self, *, farmId: str, queueId: str) -> dict[str, Any]:
+        key = self._queue_key(farmId, queueId, "GetQueue")
+        return dict(self.queues[key])
+
+    @route(
+        "GET",
+        "/farms/{farmId}/queues/{queueId}/storage-profiles",
+        "ListStorageProfilesForQueue",
+    )
+    def list_storage_profiles_for_queue(
+        self, *, farmId: str, queueId: str, **kwargs: Any
+    ) -> dict[str, Any]:
+        key = self._queue_key(farmId, queueId, "ListStorageProfilesForQueue")
+        return {"storageProfiles": list(self.storage_profiles.get(key, ()))}
+
+    @route(
+        "GET",
+        "/farms/{farmId}/queues/{queueId}/environments",
+        "ListQueueEnvironments",
+    )
+    def list_queue_environments(
+        self, *, farmId: str, queueId: str, **kwargs: Any
+    ) -> dict[str, Any]:
+        key = self._queue_key(farmId, queueId, "ListQueueEnvironments")
+        return {"environments": list(self.queue_environments.get(key, ()))}
+
+    @route(
+        "GET",
+        "/farms/{farmId}/queues/{queueId}/environments/{queueEnvironmentId}",
+        "GetQueueEnvironment",
+    )
+    def get_queue_environment(
+        self,
+        *,
+        farmId: str,
+        queueId: str,
+        queueEnvironmentId: str,
+    ) -> dict[str, Any]:
+        key = self._queue_key(farmId, queueId, "GetQueueEnvironment")
+        for environment in self.queue_environments.get(key, ()):
+            if environment.get("queueEnvironmentId") == queueEnvironmentId:
+                return dict(environment)
+        raise _resource_not_found("queueEnvironment", queueEnvironmentId, "GetQueueEnvironment")
+
+
+def _json_default(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    raise TypeError(f"Type {type(value)} is not JSON serializable")
+
+
+def _discover_routes(backend: MockDeadlineBackend) -> list[tuple[str, re.Pattern, Callable, str]]:
+    routes = []
+    for name in dir(backend):
+        function = getattr(backend, name)
+        route_info = getattr(function, "__http_route__", None)
+        if route_info is None:
+            continue
+        method, path, operation = route_info
+        pattern = re.compile("^" + re.sub(r"\{(\w+)\}", r"(?P<\1>[^/]+)", path) + "$")
+        routes.append((method, pattern, function, operation))
+    return routes
+
+
+class _ResponseValidator:
+    """Filter responses to the installed botocore model, then validate them."""
+
+    _TYPE_DEFAULTS = {
+        "string": "",
+        "integer": 0,
+        "long": 0,
+        "float": 0.0,
+        "double": 0.0,
+        "boolean": False,
+        "timestamp": datetime(1970, 1, 1, tzinfo=timezone.utc),
+        "list": [],
+        "map": {},
+        "structure": {},
+    }
+
+    def __init__(self) -> None:
+        session = botocore.session.get_session()
+        loader = session.get_component("data_loader")
+        self._model = ServiceModel(loader.load_service_model("deadline", "service-2"))
+        self._validator = ParamValidator()
+
+    def _filter(self, shape: Any, value: Any) -> Any:
+        if shape is None or value is None:
+            return value
+        if shape.type_name == "structure":
+            filtered = {
+                key: self._filter(shape.members[key], child)
+                for key, child in value.items()
+                if key in shape.members
+            }
+            for required in getattr(shape, "required_members", ()):
+                if required not in filtered and required in shape.members:
+                    filtered[required] = self._TYPE_DEFAULTS.get(shape.members[required].type_name)
+            return filtered
+        if shape.type_name == "list":
+            return [self._filter(shape.member, child) for child in value]
+        if shape.type_name == "map":
+            return {key: self._filter(shape.value, child) for key, child in value.items()}
+        return value
+
+    def filter_and_validate(self, operation_name: str, response: dict[str, Any]) -> dict[str, Any]:
+        output_shape = self._model.operation_model(operation_name).output_shape
+        if output_shape is None:
+            return response
+        filtered = self._filter(output_shape, response)
+        report = self._validator.validate(filtered, output_shape)
+        if report.has_errors():
+            raise ValueError(
+                f"Mock response for {operation_name} failed validation: "
+                f"{report.generate_report()}"
+            )
+        return filtered
+
+
+def _make_handler(
+    routes: list[tuple[str, re.Pattern, Callable, str]],
+    validator: Optional[_ResponseValidator],
+    backend: MockDeadlineBackend,
+) -> type[BaseHTTPRequestHandler]:
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, format: str, *args: Any) -> None:
+            return
+
+        def _send_json(self, status: int, body: Any, *, error_code: Optional[str] = None) -> None:
+            payload = json.dumps(body, default=_json_default).encode("utf-8")
+            try:
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(payload)))
+                if error_code:
+                    self.send_header("x-amzn-errortype", error_code)
+                self.end_headers()
+                self.wfile.write(payload)
+            except (BrokenPipeError, ConnectionAbortedError, ConnectionResetError):
+                # DCC clients can abandon in-flight requests while closing or reloading.
+                pass
+
+        def handle_one_request(self) -> None:
+            try:
+                super().handle_one_request()
+            except (BrokenPipeError, ConnectionAbortedError, ConnectionResetError):
+                self.close_connection = True
+
+        def _dispatch(self, method: str) -> None:
+            parsed = urlparse(self.path)
+            if method == "GET" and parsed.path == ADMIN_STATE_PATH:
+                self._send_json(200, backend.snapshot())
+                return
+            if method == "POST" and parsed.path == ADMIN_RESET_PATH:
+                backend.reset()
+                self._send_json(200, backend.snapshot())
+                return
+
+            for route_method, pattern, function, operation in routes:
+                match = pattern.match(parsed.path)
+                if route_method != method or match is None:
+                    continue
+                if backend.response_delay_s:
+                    time.sleep(backend.response_delay_s)
+                with backend._lock:
+                    backend.call_counts[operation] = backend.call_counts.get(operation, 0) + 1
+                    backend.request_log.append((method, parsed.path, operation))
+                try:
+                    arguments: dict[str, Any] = dict(match.groupdict())
+                    for key, values in parse_qs(parsed.query).items():
+                        arguments[key] = int(values[0]) if key in _INT_QUERY_PARAMS else values[0]
+                    length = int(self.headers.get("Content-Length", 0))
+                    if length > _MAX_BODY_BYTES:
+                        self._send_json(413, {"message": "Payload too large"})
+                        return
+                    if length:
+                        body = json.loads(self.rfile.read(length))
+                        if not isinstance(body, dict):
+                            raise ValueError("Request body must be a JSON object")
+                        arguments.update(body)
+                except (TypeError, ValueError) as error:
+                    self._send_json(
+                        400,
+                        {"message": f"Invalid request: {error}"},
+                        error_code="ValidationException",
+                    )
+                    return
+                try:
+                    result = function(**arguments)
+                    if validator is not None:
+                        result = validator.filter_and_validate(operation, result)
+                    backend._log(f"served {operation} ({method} {parsed.path}) -> 200")
+                    self._send_json(200, result)
+                except ClientError as error:
+                    details = error.response["Error"]
+                    code = details.get("Code", "InternalServerException")
+                    status = 404 if code == "ResourceNotFoundException" else 400
+                    self._send_json(
+                        status,
+                        {"message": details.get("Message", "")},
+                        error_code=code,
+                    )
+                except (BrokenPipeError, ConnectionAbortedError, ConnectionResetError):
+                    self.close_connection = True
+                except Exception as error:
+                    traceback.print_exc()
+                    try:
+                        self._send_json(
+                            500,
+                            {"message": str(error)},
+                            error_code="InternalServerException",
+                        )
+                    except (BrokenPipeError, ConnectionAbortedError, ConnectionResetError):
+                        self.close_connection = True
+                return
+
+            with backend._lock:
+                backend.unmatched_requests.append((method, parsed.path))
+            backend._log(f"UNMATCHED {method} {parsed.path} -> 404")
+            sys.stderr.write(f"[mock-deadline] 404 NO ROUTE {method} {parsed.path}\n")
+            sys.stderr.flush()
+            self._send_json(
+                404,
+                {"message": f"No route for {method} {parsed.path}"},
+                error_code="NotFoundException",
+            )
+
+        def do_GET(self) -> None:  # noqa: N802
+            self._dispatch("GET")
+
+        def do_POST(self) -> None:  # noqa: N802
+            self._dispatch("POST")
+
+        def do_PATCH(self) -> None:  # noqa: N802
+            self._dispatch("PATCH")
+
+    return Handler
+
+
+def start_server(
+    backend: MockDeadlineBackend,
+    port: int = 0,
+) -> tuple[ThreadingHTTPServer, str, threading.Thread]:
+    """Serve a mock Deadline backend over REST-JSON."""
+    routes = _discover_routes(backend)
+    validator = _ResponseValidator() if backend.validate_responses else None
+    server = ThreadingHTTPServer(
+        ("127.0.0.1", port),
+        _make_handler(routes, validator, backend),
+    )
+    actual_port = int(server.server_address[1])
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, f"http://127.0.0.1:{actual_port}", thread

--- a/src/deadline_test_fixtures/deadline_mock/config.py
+++ b/src/deadline_test_fixtures/deadline_mock/config.py
@@ -1,0 +1,75 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Configuration helpers for subprocesses that use the mock service."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Mapping, Optional
+
+MOCK_ACCESS_KEY = "testing"
+MOCK_SECRET_KEY = "testing"
+MOCK_SESSION_TOKEN = "testing"
+MOCK_REGION = "us-west-2"
+
+
+def write_deadline_config(
+    config_path: Path,
+    *,
+    farm_id: str,
+    queue_id: str,
+    job_history_dir: Path,
+    profile_name: str = "(default)",
+) -> None:
+    """Write a minimal config selecting mock resources and a temporary history."""
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        f"[profile-{profile_name} defaults]\n"
+        f"farm_id = {farm_id}\n"
+        "\n"
+        f"[profile-{profile_name} {farm_id} defaults]\n"
+        f"queue_id = {queue_id}\n"
+        "\n"
+        f"[profile-{profile_name} settings]\n"
+        f"job_history_dir = {job_history_dir}\n"
+        "\n"
+        "[settings]\n"
+        "submitter_update_notification = false\n"
+        "\n"
+        "[telemetry]\n"
+        "opt_out = true\n",
+        encoding="utf-8",
+    )
+
+
+def build_mock_environment(
+    base_env: Mapping[str, str],
+    *,
+    deadline_endpoint_url: str,
+    config_path: Path,
+    home_dir: Path,
+    mock_mode_variable: Optional[str] = "DEADLINE_CLOUD_MOCK_MODE",
+) -> dict[str, str]:
+    """Create a hermetic environment for a Deadline client subprocess.
+
+    ``mock_mode_variable`` is a consumer hook. DCC sidecars can use it to
+    disable host-prefix injection or redirect ``management.*`` to loopback.
+    Pass ``None`` when the subprocess does not need such a hook.
+    """
+    home_dir.mkdir(parents=True, exist_ok=True)
+    environment = {
+        **base_env,
+        "AWS_ENDPOINT_URL_DEADLINE": deadline_endpoint_url,
+        "AWS_ACCESS_KEY_ID": MOCK_ACCESS_KEY,
+        "AWS_SECRET_ACCESS_KEY": MOCK_SECRET_KEY,
+        "AWS_SESSION_TOKEN": MOCK_SESSION_TOKEN,
+        "AWS_DEFAULT_REGION": MOCK_REGION,
+        "AWS_REGION": MOCK_REGION,
+        "DEADLINE_CONFIG_FILE_PATH": str(config_path),
+        "DEADLINE_CLOUD_TELEMETRY_OPT_OUT": "true",
+        "HOME": str(home_dir),
+        "USERPROFILE": str(home_dir),
+    }
+    if mock_mode_variable:
+        environment[mock_mode_variable] = "1"
+    return environment

--- a/src/deadline_test_fixtures/deadline_mock/process.py
+++ b/src/deadline_test_fixtures/deadline_mock/process.py
@@ -1,0 +1,166 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Run the mock Deadline service in an independent Python process."""
+
+from __future__ import annotations
+
+import json
+import os
+import queue
+import subprocess
+import sys
+import threading
+import time
+import urllib.request
+from typing import Any, Optional
+
+from .backend import ADMIN_RESET_PATH, ADMIN_STATE_PATH
+from .scenario import MockDeadlineScenario
+
+_SCENARIO_ENV = "DEADLINE_TEST_FIXTURES_MOCK_SCENARIO"
+
+
+class RemoteDeadlineBackend:
+    """Read-only view of backend state exposed by the admin endpoint."""
+
+    def __init__(self, base_url: str, identifiers: dict[str, str]) -> None:
+        self.base_url = base_url
+        self._identifiers = identifiers
+
+    @property
+    def farm_id(self) -> str:
+        return self._identifiers["farm_id"]
+
+    @property
+    def queue_id(self) -> str:
+        return self._identifiers["queue_id"]
+
+    def snapshot(self) -> dict[str, Any]:
+        with urllib.request.urlopen(f"{self.base_url}{ADMIN_STATE_PATH}", timeout=5) as response:
+            return json.loads(response.read().decode("utf-8"))
+
+    def reset(self) -> None:
+        request = urllib.request.Request(
+            f"{self.base_url}{ADMIN_RESET_PATH}", data=b"", method="POST"
+        )
+        with urllib.request.urlopen(request, timeout=5):
+            pass
+
+    @property
+    def call_counts(self) -> dict[str, int]:
+        return self.snapshot()["call_counts"]
+
+    @property
+    def request_log(self) -> list[tuple[str, str, str]]:
+        return [tuple(request) for request in self.snapshot()["request_log"]]
+
+    @property
+    def unmatched_requests(self) -> list[tuple[str, str]]:
+        return [tuple(request) for request in self.snapshot()["unmatched_requests"]]
+
+    @property
+    def resources(self) -> dict[str, list[dict[str, Any]]]:
+        return self.snapshot()["resources"]
+
+
+class MockDeadlineServerProcess:
+    """Lifecycle handle for an out-of-process mock server.
+
+    A separate process is required when native accessibility calls hold the
+    test process's GIL while a DCC subprocess is making service requests.
+    """
+
+    def __init__(
+        self,
+        scenario: Optional[MockDeadlineScenario] = None,
+        *,
+        startup_timeout: float = 30.0,
+    ) -> None:
+        self.scenario = scenario or MockDeadlineScenario()
+        self.startup_timeout = startup_timeout
+        self._process: Optional[subprocess.Popen[str]] = None
+        self.base_url: Optional[str] = None
+        self.backend: Optional[RemoteDeadlineBackend] = None
+
+    def start(self) -> "MockDeadlineServerProcess":
+        if self._process is not None:
+            raise RuntimeError("Mock Deadline server process is already started")
+        startup_deadline = time.monotonic() + self.startup_timeout
+        environment = {
+            **os.environ,
+            _SCENARIO_ENV: json.dumps(self.scenario.to_dict()),
+        }
+        self._process = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "deadline_test_fixtures.deadline_mock._server_child",
+            ],
+            env=environment,
+            stdout=subprocess.PIPE,
+            stderr=None,
+            stdin=subprocess.DEVNULL,
+            text=True,
+        )
+        assert self._process.stdout is not None
+        stdout = self._process.stdout
+        startup_output: queue.Queue[str] = queue.Queue(maxsize=1)
+        threading.Thread(
+            target=lambda: startup_output.put(stdout.readline()),
+            daemon=True,
+        ).start()
+        try:
+            line = startup_output.get(timeout=self.startup_timeout).strip()
+        except queue.Empty:
+            self.stop()
+            raise RuntimeError(
+                f"Mock Deadline server did not produce a URL within " f"{self.startup_timeout}s"
+            ) from None
+        if not line.startswith("http"):
+            return_code = self._process.poll()
+            self.stop()
+            raise RuntimeError(
+                f"Mock Deadline server failed to start "
+                f"(output={line!r}, returncode={return_code})"
+            )
+        self.base_url = line
+        self.backend = RemoteDeadlineBackend(
+            line,
+            {
+                "farm_id": self.scenario.farm_id,
+                "queue_id": self.scenario.queue_id,
+            },
+        )
+        self._wait_ready(startup_deadline)
+        return self
+
+    def _wait_ready(self, startup_deadline: float) -> None:
+        assert self.backend is not None
+        last_error: Optional[Exception] = None
+        while time.monotonic() < startup_deadline:
+            try:
+                self.backend.snapshot()
+                return
+            except Exception as error:
+                last_error = error
+                time.sleep(0.1)
+        self.stop()
+        raise RuntimeError(f"Mock Deadline server did not become ready: {last_error!r}")
+
+    def stop(self) -> None:
+        if self._process is not None and self._process.poll() is None:
+            self._process.terminate()
+            try:
+                self._process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self._process.kill()
+                self._process.wait(timeout=5)
+        self._process = None
+        self.base_url = None
+        self.backend = None
+
+    def __enter__(self) -> "MockDeadlineServerProcess":
+        return self.start()
+
+    def __exit__(self, *exc: Any) -> None:
+        self.stop()

--- a/src/deadline_test_fixtures/deadline_mock/scenario.py
+++ b/src/deadline_test_fixtures/deadline_mock/scenario.py
@@ -1,0 +1,104 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Serializable data used to seed the hermetic Deadline service."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import asdict, dataclass, field
+from typing import Any, Mapping
+
+FAKE_ACCOUNT_ID = "123456789012"
+DEFAULT_FARM_ID = "farm-0000000000000000000000000000000a"
+DEFAULT_QUEUE_ID = "queue-0000000000000000000000000000000b"
+
+_FAKE_PRINCIPAL = f"arn:aws:sts::{FAKE_ACCOUNT_ID}:assumed-role/DeadlineTestFixtures/test-runner"
+_FAKE_QUEUE_ROLE = f"arn:aws:iam::{FAKE_ACCOUNT_ID}:role/service-role/DeadlineTestFixturesQueueRole"
+
+
+def _default_farm() -> dict[str, Any]:
+    return {
+        "farmId": DEFAULT_FARM_ID,
+        "displayName": "TestFarm",
+        "description": "",
+        "createdAt": "2024-01-01T00:00:00+00:00",
+        "createdBy": _FAKE_PRINCIPAL,
+        "updatedAt": "2024-01-01T00:00:00+00:00",
+        "updatedBy": _FAKE_PRINCIPAL,
+        "costScaleFactor": 1.0,
+    }
+
+
+def _default_queue() -> dict[str, Any]:
+    return {
+        "farmId": DEFAULT_FARM_ID,
+        "queueId": DEFAULT_QUEUE_ID,
+        "displayName": "TestQueue",
+        "status": "SCHEDULING",
+        "defaultBudgetAction": "NONE",
+        "description": "",
+        "createdAt": "2024-01-01T00:00:00+00:00",
+        "createdBy": _FAKE_PRINCIPAL,
+        "updatedAt": "2024-01-01T00:00:00+00:00",
+        "updatedBy": _FAKE_PRINCIPAL,
+        "jobAttachmentSettings": {
+            "s3BucketName": "deadline-test-fixtures-bucket",
+            "rootPrefix": "DeadlineCloud",
+        },
+        "roleArn": _FAKE_QUEUE_ROLE,
+        "schedulingConfiguration": {"priorityFifo": {}},
+    }
+
+
+@dataclass(frozen=True)
+class MockDeadlineScenario:
+    """Resources returned by :class:`MockDeadlineBackend`.
+
+    The default scenario covers the read operations used while a Deadline
+    submitter opens and exports a job bundle. Consumers can supply queue
+    environments or storage profiles without implementing another HTTP mock.
+    """
+
+    farm: Mapping[str, Any] = field(default_factory=_default_farm)
+    queue: Mapping[str, Any] = field(default_factory=_default_queue)
+    queue_environments: tuple[Mapping[str, Any], ...] = ()
+    storage_profiles: tuple[Mapping[str, Any], ...] = ()
+    response_delay_s: float = 0.0
+
+    @property
+    def farm_id(self) -> str:
+        return str(self.farm["farmId"])
+
+    @property
+    def queue_id(self) -> str:
+        return str(self.queue["queueId"])
+
+    def seed(self, backend: Any) -> None:
+        """Replace a backend's resources with this scenario."""
+        backend.farms = {self.farm_id: deepcopy(dict(self.farm))}
+        backend.queues = {
+            (self.farm_id, self.queue_id): deepcopy(dict(self.queue)),
+        }
+        backend.queue_environments = {
+            (self.farm_id, self.queue_id): [
+                deepcopy(dict(environment)) for environment in self.queue_environments
+            ]
+        }
+        backend.storage_profiles = {
+            (self.farm_id, self.queue_id): [
+                deepcopy(dict(profile)) for profile in self.storage_profiles
+            ]
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> "MockDeadlineScenario":
+        return cls(
+            farm=value["farm"],
+            queue=value["queue"],
+            queue_environments=tuple(value.get("queue_environments", ())),
+            storage_profiles=tuple(value.get("storage_profiles", ())),
+            response_delay_s=float(value.get("response_delay_s", 0.0)),
+        )

--- a/src/deadline_test_fixtures/images.py
+++ b/src/deadline_test_fixtures/images.py
@@ -1,0 +1,83 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Image assertions shared by DCC render integration tests."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+
+
+def _normalized_name(name: str) -> str:
+    return re.sub(r"_+", "_", name)
+
+
+def _match_actual(
+    actual_dir: Path,
+    expected_name: str,
+    *,
+    collapse_underscores: bool,
+) -> Path:
+    exact = actual_dir / expected_name
+    if exact.is_file() or not collapse_underscores:
+        return exact
+    normalized = _normalized_name(expected_name)
+    matches = [
+        path
+        for path in actual_dir.iterdir()
+        if path.is_file() and _normalized_name(path.name) == normalized
+    ]
+    if len(matches) == 1:
+        return matches[0]
+    return exact
+
+
+def assert_images_close(
+    expected_dir: Path,
+    actual_dir: Path,
+    *,
+    absolute_tolerance: float = 2,
+    collapse_underscores: bool = False,
+    allow_extra: bool = False,
+) -> None:
+    """Compare render files by shape and per-channel absolute tolerance."""
+    expected_files = sorted(path for path in expected_dir.iterdir() if path.is_file())
+    if not expected_files:
+        raise AssertionError(f"No expected images found in {expected_dir}")
+
+    matched_actual: set[Path] = set()
+    for expected_path in expected_files:
+        actual_path = _match_actual(
+            actual_dir,
+            expected_path.name,
+            collapse_underscores=collapse_underscores,
+        )
+        if not actual_path.is_file():
+            raise AssertionError(f"Missing rendered image: {actual_path}")
+        matched_actual.add(actual_path)
+        with Image.open(expected_path) as expected_image:
+            expected = np.asarray(expected_image)
+        with Image.open(actual_path) as actual_image:
+            actual = np.asarray(actual_image)
+        if actual.shape != expected.shape:
+            raise AssertionError(
+                f"Image dimensions differ for {expected_path.name}: "
+                f"{actual.shape} != {expected.shape}"
+            )
+        if not np.allclose(actual, expected, atol=absolute_tolerance):
+            maximum_delta = float(
+                np.abs(actual.astype(np.float64) - expected.astype(np.float64)).max()
+            )
+            raise AssertionError(
+                f"Image pixels differ for {expected_path.name}: "
+                f"maximum delta {maximum_delta} exceeds {absolute_tolerance}"
+            )
+
+    unexpected = sorted(
+        path.name for path in actual_dir.iterdir() if path.is_file() and path not in matched_actual
+    )
+    if unexpected and not allow_extra:
+        raise AssertionError(f"Unexpected rendered images in {actual_dir}: {unexpected}")

--- a/src/deadline_test_fixtures/job_bundle/__init__.py
+++ b/src/deadline_test_fixtures/job_bundle/__init__.py
@@ -1,0 +1,19 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Reusable filesystem and assertion helpers for DCC job bundles."""
+
+from .cases import JobBundleCase
+from .compare import (
+    BundleNormalization,
+    assert_job_bundles_equal,
+    assert_valid_job_bundle,
+    find_complete_job_bundle,
+)
+
+__all__ = [
+    "BundleNormalization",
+    "JobBundleCase",
+    "assert_job_bundles_equal",
+    "assert_valid_job_bundle",
+    "find_complete_job_bundle",
+]

--- a/src/deadline_test_fixtures/job_bundle/cases.py
+++ b/src/deadline_test_fixtures/job_bundle/cases.py
@@ -1,0 +1,25 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Conventional filesystem layout for DCC job-bundle cases."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from shutil import rmtree
+
+
+@dataclass(frozen=True)
+class JobBundleCase:
+    """A test case with a runtime ``actual/`` output folder."""
+
+    root: Path
+
+    @property
+    def actual_dir(self) -> Path:
+        return self.root / "actual"
+
+    def prepare_actual_dir(self) -> Path:
+        rmtree(self.actual_dir, ignore_errors=True)
+        self.actual_dir.mkdir(parents=True)
+        return self.actual_dir

--- a/src/deadline_test_fixtures/job_bundle/compare.py
+++ b/src/deadline_test_fixtures/job_bundle/compare.py
@@ -1,0 +1,144 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Structural comparison helpers for OpenJD job bundles."""
+
+from __future__ import annotations
+
+import copy
+import json
+import re
+import subprocess
+from dataclasses import dataclass, field
+from difflib import unified_diff
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+import yaml
+
+DEFAULT_BUNDLE_FILES = (
+    "template.yaml",
+    "parameter_values.yaml",
+    "asset_references.yaml",
+)
+
+
+@dataclass(frozen=True)
+class BundleNormalization:
+    """Policy for removing expected machine/build differences."""
+
+    replacements: Mapping[str, str] = field(default_factory=dict)
+    regex_replacements: Sequence[tuple[str, str]] = ()
+    normalized_parameter_values: Mapping[str, Any] = field(default_factory=dict)
+    ignored_template_keys: Sequence[str] = ()
+    normalize_path_separators: bool = True
+    files: Sequence[str] = DEFAULT_BUNDLE_FILES
+
+
+def _normalize_string(value: str, policy: BundleNormalization) -> str:
+    for old, new in policy.replacements.items():
+        value = value.replace(old, new)
+    for pattern, replacement in policy.regex_replacements:
+        value = re.sub(pattern, replacement, value)
+    if policy.normalize_path_separators:
+        value = value.replace("\\", "/")
+    return value
+
+
+def _normalize_value(value: Any, policy: BundleNormalization) -> Any:
+    if isinstance(value, str):
+        return _normalize_string(value, policy)
+    if isinstance(value, list):
+        return [_normalize_value(child, policy) for child in value]
+    if isinstance(value, dict):
+        return {key: _normalize_value(child, policy) for key, child in value.items()}
+    return value
+
+
+def _load_normalized(
+    path: Path,
+    policy: BundleNormalization,
+) -> Any:
+    value = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if path.name == "template.yaml" and isinstance(value, dict):
+        value = copy.deepcopy(value)
+        for key in policy.ignored_template_keys:
+            value.pop(key, None)
+    if path.name == "parameter_values.yaml" and isinstance(value, dict):
+        value = copy.deepcopy(value)
+        for parameter in value.get("parameterValues", []):
+            name = parameter.get("name")
+            if name in policy.normalized_parameter_values:
+                parameter["value"] = policy.normalized_parameter_values[name]
+    return _normalize_value(value, policy)
+
+
+def _document_text(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, indent=2, ensure_ascii=False)
+
+
+def assert_job_bundles_equal(
+    expected_dir: Path,
+    actual_dir: Path,
+    *,
+    normalization: BundleNormalization = BundleNormalization(),
+) -> None:
+    """Assert that required bundle documents are structurally equal."""
+    missing_expected = [name for name in normalization.files if not (expected_dir / name).is_file()]
+    missing_actual = [name for name in normalization.files if not (actual_dir / name).is_file()]
+    if missing_expected or missing_actual:
+        raise AssertionError(
+            f"Missing job-bundle files: expected={missing_expected}, actual={missing_actual}"
+        )
+
+    differences: list[str] = []
+    for name in normalization.files:
+        expected = _load_normalized(expected_dir / name, normalization)
+        actual = _load_normalized(actual_dir / name, normalization)
+        if expected == actual:
+            continue
+        expected_text = _document_text(expected)
+        actual_text = _document_text(actual)
+        differences.append(
+            "\n".join(
+                unified_diff(
+                    expected_text.splitlines(),
+                    actual_text.splitlines(),
+                    fromfile=f"expected/{name}",
+                    tofile=f"actual/{name}",
+                    lineterm="",
+                )
+            )
+        )
+    if differences:
+        raise AssertionError("Job bundles differ:\n" + "\n".join(differences))
+
+
+def find_complete_job_bundle(
+    history_dir: Path,
+    *,
+    files: Sequence[str] = DEFAULT_BUNDLE_FILES,
+) -> Path | None:
+    """Return the newest complete ``history/YYYY-mm/bundle`` directory."""
+    candidates = [path for path in history_dir.glob("*/*") if path.is_dir()]
+    candidates.sort(key=lambda path: path.stat().st_mtime, reverse=True)
+    required = set(files)
+    for candidate in candidates:
+        present = {path.name for path in candidate.iterdir() if path.is_file()}
+        if required.issubset(present):
+            return candidate
+    return None
+
+
+def assert_valid_job_bundle(template_path: Path) -> None:
+    """Run ``openjd check`` and assert that validation succeeds."""
+    result = subprocess.run(
+        ["openjd", "check", str(template_path), "--output", "json"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise AssertionError(f"openjd check failed with {result.returncode}:\n{result.stderr}")
+    response = json.loads(result.stdout)
+    if response.get("status") != "success":
+        raise AssertionError(f"openjd check returned {response!r}")

--- a/src/deadline_test_fixtures/xa11y/__init__.py
+++ b/src/deadline_test_fixtures/xa11y/__init__.py
@@ -1,0 +1,11 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Cross-platform accessibility helpers for subprocess UI tests."""
+
+from .app import find_accessibility_app
+from .submitter import SharedSubmitterDialog
+
+__all__ = [
+    "SharedSubmitterDialog",
+    "find_accessibility_app",
+]

--- a/src/deadline_test_fixtures/xa11y/app.py
+++ b/src/deadline_test_fixtures/xa11y/app.py
@@ -1,0 +1,44 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Cross-platform accessibility application discovery."""
+
+from __future__ import annotations
+
+import time
+from typing import Optional
+
+import xa11y
+
+STARTUP_TIMEOUT = 60.0
+
+
+def find_accessibility_app(
+    pid: int,
+    timeout: float = STARTUP_TIMEOUT,
+    *,
+    name_prefix: Optional[str] = None,
+) -> xa11y.App:
+    """Find an accessibility app by PID and optional name prefix.
+
+    ``name_prefix`` is useful for DCC-hosted Qt dialogs which appear as a
+    separate accessibility app sharing the host process ID on Windows.
+    """
+    deadline = time.monotonic() + timeout
+    last_apps: list[xa11y.App] = []
+    while time.monotonic() < deadline:
+        try:
+            last_apps = xa11y.App.list()
+            matching_pid = [app for app in last_apps if app.pid == pid]
+            if name_prefix is not None:
+                matching_pid = [
+                    app for app in matching_pid if app.name and app.name.startswith(name_prefix)
+                ]
+            if matching_pid:
+                return matching_pid[0]
+        except Exception:
+            # Accessibility backends can fail transiently while applications start.
+            pass
+        time.sleep(0.25)
+    apps = [(app.name, app.pid) for app in last_apps]
+    qualifier = f" and name prefix {name_prefix!r}" if name_prefix else ""
+    raise TimeoutError(f"No accessibility app appeared for PID {pid}{qualifier}; apps={apps}")

--- a/src/deadline_test_fixtures/xa11y/controls.py
+++ b/src/deadline_test_fixtures/xa11y/controls.py
@@ -1,0 +1,163 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Robust cross-platform interactions for common Qt accessibility widgets."""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Callable, Optional, Union
+
+import xa11y
+
+WIDGET_TIMEOUT = 60.0
+TAB_SHARED = "Shared job settings"
+TAB_JOB_SPECIFIC = "Job-specific settings"
+ControlRoot = Union[xa11y.App, xa11y.Locator]
+
+
+def _observe_pause() -> None:
+    delay = float(os.environ.get("DIALOG_CONFIG_OBSERVE_DELAY_S", "0"))
+    if delay > 0:
+        time.sleep(delay)
+
+
+def _descendant(root: ControlRoot, selector: str) -> xa11y.Locator:
+    if isinstance(root, xa11y.App):
+        return root.locator(selector)
+    return root.descendant(selector)
+
+
+def switch_to_tab(
+    dialog: ControlRoot,
+    tab_name: str,
+    *,
+    timeout: float = WIDGET_TIMEOUT,
+) -> None:
+    """Activate a Qt tab across AX, AT-SPI, and UIA role names."""
+    tab = _descendant(
+        dialog,
+        f'tab[name="{tab_name}"], '
+        f'page_tab[name="{tab_name}"], '
+        f'radio_button[name="{tab_name}"]',
+    )
+    tab.wait_visible(timeout=timeout)
+    tab.press()
+    time.sleep(0.5)
+    _observe_pause()
+
+
+def set_text_field(
+    dialog: ControlRoot,
+    name: str,
+    value: str,
+    nth: Optional[int] = None,
+    *,
+    timeout: float = WIDGET_TIMEOUT,
+) -> str:
+    """Set a text field and return its previous value."""
+    field = _descendant(dialog, f'text_field[name="{name}"]')
+    if nth is not None:
+        field = field.nth(nth)
+    field.wait_visible(timeout=timeout)
+    previous = field.element().value or ""
+    field.set_value(value)
+    _observe_pause()
+    return previous
+
+
+def _step_spin_button(spin: xa11y.Locator, target: int) -> None:
+    current = int(spin.element().value or "0")
+    for _ in range(10_000):
+        if current == target:
+            return
+        spin.increment() if current < target else spin.decrement()
+        _observe_pause()
+        current = int(spin.element().value or "0")
+    raise AssertionError(f"Spin button did not reach {target}; stopped at {current}")
+
+
+def set_spin_button(
+    dialog: xa11y.Locator,
+    name: str,
+    nth: int,
+    target: int,
+    *,
+    timeout: float = WIDGET_TIMEOUT,
+) -> None:
+    spin = dialog.descendant(f'spin_button[name="{name}"]').nth(nth)
+    spin.wait_visible(timeout=timeout)
+    _step_spin_button(spin, target)
+
+
+def set_spin_button_in_group(
+    dialog: xa11y.Locator,
+    group: str,
+    nth: int,
+    target: int,
+    *,
+    timeout: float = WIDGET_TIMEOUT,
+) -> None:
+    spin = dialog.descendant(f'group[name="{group}"]').descendant("spin_button").nth(nth)
+    spin.wait_visible(timeout=timeout)
+    _step_spin_button(spin, target)
+
+
+def is_checked(box: xa11y.Locator) -> bool:
+    value = (box.element().checked or "").lower()
+    return value in ("on", "true", "1", "checked")
+
+
+def toggle_checkbox(
+    dialog: xa11y.Locator,
+    name: str,
+    *,
+    timeout: float = WIDGET_TIMEOUT,
+) -> None:
+    box = dialog.descendant(f'check_box[name="{name}"]')
+    box.wait_visible(timeout=timeout)
+    box.toggle()
+    _observe_pause()
+
+
+def set_checkbox(
+    dialog: xa11y.Locator,
+    name: str,
+    checked: bool,
+    *,
+    timeout: float = WIDGET_TIMEOUT,
+) -> None:
+    box = dialog.descendant(f'check_box[name="{name}"]')
+    box.wait_visible(timeout=timeout)
+    if is_checked(box) != checked:
+        box.toggle()
+        _observe_pause()
+
+
+def set_job_name(dialog: ControlRoot, name: str) -> None:
+    switch_to_tab(dialog, TAB_SHARED)
+    set_text_field(dialog, "Name", name)
+
+
+def set_priority(dialog: xa11y.Locator, value: int) -> None:
+    switch_to_tab(dialog, TAB_SHARED)
+    set_spin_button(dialog, "Job Properties", 1, value)
+
+
+def set_max_failed_tasks(dialog: xa11y.Locator, value: int) -> None:
+    switch_to_tab(dialog, TAB_SHARED)
+    set_spin_button(dialog, "Job Properties", 2, value)
+
+
+def set_max_retries(dialog: xa11y.Locator, value: int) -> None:
+    switch_to_tab(dialog, TAB_SHARED)
+    set_spin_button(dialog, "Job Properties", 3, value)
+
+
+def transform_text_field(field: xa11y.Locator, transform: Callable[[str], str]) -> str:
+    """Transform a field without hard-coding its environment-specific value."""
+    current = field.element().value or ""
+    new_value = transform(current)
+    field.set_value(new_value)
+    _observe_pause()
+    return new_value

--- a/src/deadline_test_fixtures/xa11y/submitter.py
+++ b/src/deadline_test_fixtures/xa11y/submitter.py
@@ -1,0 +1,26 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+"""Minimal page object for controls shared by Deadline submitter dialogs."""
+
+from __future__ import annotations
+
+from typing import Union
+
+import xa11y
+
+SubmitterRoot = Union[xa11y.App, xa11y.Locator]
+
+
+class SharedSubmitterDialog:
+    """Page object for controls supplied by the Deadline submitter UI."""
+
+    def __init__(self, root: SubmitterRoot) -> None:
+        self.root = root
+
+    def _descendant(self, selector: str) -> xa11y.Locator:
+        if isinstance(self.root, xa11y.App):
+            return self.root.locator(selector)
+        return self.root.descendant(selector)
+
+    def button(self, name: str) -> xa11y.Locator:
+        return self._descendant(f'button[name="{name}"]')

--- a/test/unit/deadline_mock/__init__.py
+++ b/test/unit/deadline_mock/__init__.py
@@ -1,0 +1,1 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/test/unit/deadline_mock/test_backend.py
+++ b/test/unit/deadline_mock/test_backend.py
@@ -1,0 +1,106 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import json
+from contextlib import closing
+from typing import Union
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+import boto3
+import pytest
+from botocore.config import Config
+
+from deadline_test_fixtures.deadline_mock import (
+    MockDeadlineBackend,
+    MockDeadlineScenario,
+    start_server,
+)
+
+
+def _client(endpoint_url: str):
+    return boto3.client(
+        "deadline",
+        endpoint_url=endpoint_url,
+        aws_access_key_id="testing",
+        aws_secret_access_key="testing",
+        region_name="us-west-2",
+        config=Config(inject_host_prefix=False),
+    )
+
+
+@pytest.fixture
+def mock_server():
+    scenario = MockDeadlineScenario(response_delay_s=0)
+    backend = MockDeadlineBackend(scenario)
+    server, endpoint_url, _ = start_server(backend)
+    try:
+        yield backend, endpoint_url
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_http_server_serves_submitter_resources_and_records_calls(mock_server):
+    backend, endpoint_url = mock_server
+    client = _client(endpoint_url)
+
+    farms = client.list_farms()
+    queues = client.list_queues(farmId=backend.farm_id)
+    environments = client.list_queue_environments(
+        farmId=backend.farm_id,
+        queueId=backend.queue_id,
+    )
+
+    assert farms["farms"][0]["farmId"] == backend.farm_id
+    assert queues["queues"][0]["queueId"] == backend.queue_id
+    assert environments["environments"] == []
+    assert backend.call_counts == {
+        "ListFarms": 1,
+        "ListQueues": 1,
+        "ListQueueEnvironments": 1,
+    }
+    assert backend.unmatched_requests == []
+
+
+def test_http_server_records_unmatched_requests(mock_server):
+    backend, endpoint_url = mock_server
+
+    with pytest.raises(HTTPError) as error:
+        with closing(urlopen(f"{endpoint_url}/not-a-deadline-route")):
+            pass
+
+    assert error.value.code == 404
+    assert backend.unmatched_requests == [("GET", "/not-a-deadline-route")]
+
+
+def test_http_server_returns_validation_errors_for_malformed_requests(mock_server):
+    _, endpoint_url = mock_server
+    requests: list[Union[str, Request]] = [
+        f"{endpoint_url}/2023-10-12/farms?maxResults=invalid",
+        Request(
+            f"{endpoint_url}/2023-10-12/farms",
+            data=b"{",
+            method="GET",
+        ),
+    ]
+
+    for request in requests:
+        with pytest.raises(HTTPError) as caught:
+            urlopen(request, timeout=2)
+
+        with closing(caught.value) as error:
+            assert error.code == 400
+            assert error.headers["x-amzn-errortype"] == "ValidationException"
+            assert json.loads(error.read())["message"].startswith("Invalid request:")
+
+
+def test_reset_restores_scenario_and_observability():
+    backend = MockDeadlineBackend()
+    backend.call_counts["ListFarms"] = 3
+    backend.farms.clear()
+
+    backend.reset()
+
+    assert backend.call_counts == {}
+    assert list(backend.farms) == [backend.farm_id]
+    assert backend.snapshot()["identifiers"]["queue_id"] == backend.queue_id

--- a/test/unit/deadline_mock/test_config.py
+++ b/test/unit/deadline_mock/test_config.py
@@ -1,0 +1,41 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from deadline_test_fixtures.deadline_mock import (
+    build_mock_environment,
+    write_deadline_config,
+)
+
+
+def test_write_deadline_config_selects_mock_resources(tmp_path):
+    config_path = tmp_path / "deadline.config"
+    history = tmp_path / "history"
+
+    write_deadline_config(
+        config_path,
+        farm_id="farm-test",
+        queue_id="queue-test",
+        job_history_dir=history,
+    )
+
+    content = config_path.read_text(encoding="utf-8")
+    assert "farm_id = farm-test" in content
+    assert "queue_id = queue-test" in content
+    assert f"job_history_dir = {history}" in content
+    assert "submitter_update_notification = false" in content
+    assert "opt_out = true" in content
+
+
+def test_build_mock_environment_is_hermetic(tmp_path):
+    environment = build_mock_environment(
+        {"PATH": "existing"},
+        deadline_endpoint_url="http://127.0.0.1:1234",
+        config_path=tmp_path / "deadline.config",
+        home_dir=tmp_path / "home",
+    )
+
+    assert environment["PATH"] == "existing"
+    assert environment["AWS_ENDPOINT_URL_DEADLINE"] == "http://127.0.0.1:1234"
+    assert environment["AWS_ACCESS_KEY_ID"] == "testing"
+    assert environment["HOME"] == str(tmp_path / "home")
+    assert environment["USERPROFILE"] == str(tmp_path / "home")
+    assert environment["DEADLINE_CLOUD_MOCK_MODE"] == "1"

--- a/test/unit/deadline_mock/test_process.py
+++ b/test/unit/deadline_mock/test_process.py
@@ -1,0 +1,42 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import threading
+
+import pytest
+
+from deadline_test_fixtures.deadline_mock import MockDeadlineServerProcess
+from deadline_test_fixtures.deadline_mock import process as process_module
+
+
+def test_process_server_startup_timeout_covers_initial_output(monkeypatch):
+    never_ready = threading.Event()
+
+    class BlockingOutput:
+        def readline(self):
+            never_ready.wait()
+            return ""
+
+    class BlockingProcess:
+        stdout = BlockingOutput()
+        terminated = False
+
+        def poll(self):
+            return None
+
+        def terminate(self):
+            self.terminated = True
+
+        def wait(self, timeout):
+            return 0
+
+        def kill(self):
+            self.terminated = True
+
+    process = BlockingProcess()
+    monkeypatch.setattr(process_module.subprocess, "Popen", lambda *args, **kwargs: process)
+
+    with pytest.raises(RuntimeError, match="did not produce a URL"):
+        MockDeadlineServerProcess(startup_timeout=0.01).start()
+
+    assert process.terminated
+    never_ready.set()

--- a/test/unit/job_bundle/__init__.py
+++ b/test/unit/job_bundle/__init__.py
@@ -1,0 +1,1 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/test/unit/job_bundle/test_compare.py
+++ b/test/unit/job_bundle/test_compare.py
@@ -1,0 +1,109 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from deadline_test_fixtures.job_bundle import (
+    BundleNormalization,
+    JobBundleCase,
+    assert_job_bundles_equal,
+    find_complete_job_bundle,
+)
+
+
+def _write_bundle(directory: Path, root: str = "ROOT") -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "template.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "specificationVersion": "jobtemplate-2023-09",
+                "name": "Test",
+                "jobEnvironments": [{"name": "moving"}],
+                "steps": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (directory / "parameter_values.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "parameterValues": [
+                    {"name": "SceneFile", "value": f"{root}\\scene.test"},
+                    {"name": "SubmitterIntegrationVersion", "value": "1.2.3"},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    (directory / "asset_references.yaml").write_text(
+        yaml.safe_dump({"assetReferences": {"inputs": {"filenames": [f"{root}\\scene.test"]}}}),
+        encoding="utf-8",
+    )
+
+
+def test_bundle_comparison_uses_structural_normalization(tmp_path):
+    expected = tmp_path / "expected"
+    actual = tmp_path / "actual"
+    _write_bundle(expected, "PLACEHOLDER")
+    _write_bundle(actual, "/workspace")
+
+    assert_job_bundles_equal(
+        expected,
+        actual,
+        normalization=BundleNormalization(
+            replacements={"PLACEHOLDER": "/workspace"},
+            normalized_parameter_values={"SubmitterIntegrationVersion": "NORMALIZED"},
+        ),
+    )
+
+
+def test_bundle_comparison_reports_structural_diff(tmp_path):
+    expected = tmp_path / "expected"
+    actual = tmp_path / "actual"
+    _write_bundle(expected)
+    _write_bundle(actual)
+    (actual / "template.yaml").write_text("name: Different\n", encoding="utf-8")
+
+    with pytest.raises(AssertionError, match="Job bundles differ"):
+        assert_job_bundles_equal(expected, actual)
+
+
+def test_bundle_comparison_only_ignores_explicit_template_keys(tmp_path):
+    expected = tmp_path / "expected"
+    actual = tmp_path / "actual"
+    _write_bundle(expected)
+    _write_bundle(actual)
+    actual_template = yaml.safe_load((actual / "template.yaml").read_text(encoding="utf-8"))
+    actual_template["jobEnvironments"] = [{"name": "changed"}]
+    (actual / "template.yaml").write_text(
+        yaml.safe_dump(actual_template),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(AssertionError, match="Job bundles differ"):
+        assert_job_bundles_equal(expected, actual)
+
+    assert_job_bundles_equal(
+        expected,
+        actual,
+        normalization=BundleNormalization(ignored_template_keys=("jobEnvironments",)),
+    )
+
+
+def test_find_complete_bundle(tmp_path):
+    history_bundle = tmp_path / "history" / "2026-07" / "bundle"
+    _write_bundle(history_bundle)
+    assert find_complete_job_bundle(tmp_path / "history") == history_bundle
+
+
+def test_job_bundle_case_prepares_actual_directory(tmp_path):
+    case = JobBundleCase(tmp_path / "cube")
+    case.actual_dir.mkdir(parents=True)
+    (case.actual_dir / "stale").write_text("old", encoding="utf-8")
+
+    result = case.prepare_actual_dir()
+
+    assert result == case.actual_dir
+    assert list(result.iterdir()) == []

--- a/test/unit/test_images.py
+++ b/test/unit/test_images.py
@@ -1,0 +1,52 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from deadline_test_fixtures.images import assert_images_close
+
+
+def _write_image(path: Path, value: int, shape: tuple[int, int, int] = (2, 2, 3)) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    Image.fromarray(np.full(shape, value, dtype=np.uint8)).save(path)
+
+
+def test_assert_images_close_accepts_pixels_within_absolute_tolerance(tmp_path):
+    _write_image(tmp_path / "expected" / "render.png", 10)
+    _write_image(tmp_path / "actual" / "render.png", 12)
+
+    assert_images_close(tmp_path / "expected", tmp_path / "actual")
+
+
+def test_assert_images_close_reports_dimension_difference(tmp_path):
+    _write_image(tmp_path / "expected" / "render.png", 10)
+    _write_image(tmp_path / "actual" / "render.png", 10, shape=(3, 2, 3))
+
+    with pytest.raises(AssertionError, match="dimensions differ"):
+        assert_images_close(tmp_path / "expected", tmp_path / "actual")
+
+
+def test_assert_images_close_can_match_collapsed_underscores(tmp_path):
+    _write_image(tmp_path / "expected" / "render___1.png", 10)
+    _write_image(tmp_path / "actual" / "render_1.png", 10)
+
+    assert_images_close(
+        tmp_path / "expected",
+        tmp_path / "actual",
+        collapse_underscores=True,
+    )
+
+
+def test_assert_images_close_can_allow_extra_files(tmp_path):
+    _write_image(tmp_path / "expected" / "render.png", 10)
+    _write_image(tmp_path / "actual" / "render.png", 10)
+    _write_image(tmp_path / "actual" / "extra.png", 10)
+
+    assert_images_close(
+        tmp_path / "expected",
+        tmp_path / "actual",
+        allow_extra=True,
+    )

--- a/test/unit/test_xa11y.py
+++ b/test/unit/test_xa11y.py
@@ -1,0 +1,56 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import xa11y
+
+from deadline_test_fixtures.xa11y import (
+    SharedSubmitterDialog,
+    find_accessibility_app,
+)
+
+
+def test_find_accessibility_app_prefers_matching_process_id(monkeypatch):
+    wrong = SimpleNamespace(pid=1, name="Wrong")
+    expected = SimpleNamespace(pid=42, name="Expected")
+    monkeypatch.setattr(xa11y.App, "list", lambda: [wrong, expected])
+
+    result = find_accessibility_app(42, timeout=0.1)
+
+    assert result is expected
+
+
+def test_find_accessibility_app_does_not_guess_an_unrelated_app(monkeypatch):
+    unrelated = SimpleNamespace(pid=1, name="Unrelated Helper")
+    monkeypatch.setattr(xa11y.App, "list", lambda: [unrelated])
+
+    with pytest.raises(TimeoutError):
+        find_accessibility_app(42, timeout=0.01)
+
+
+def test_find_accessibility_app_filters_matching_pid_by_name_prefix(monkeypatch):
+    host = SimpleNamespace(pid=42, name="Cinema 4D")
+    submitter = SimpleNamespace(pid=42, name="Deadline Cloud Cinema4D Submitter 1.0")
+    monkeypatch.setattr(xa11y.App, "list", lambda: [host, submitter])
+
+    result = find_accessibility_app(
+        42,
+        timeout=0.1,
+        name_prefix="Deadline Cloud Cinema4D Submitter",
+    )
+
+    assert result is submitter
+
+
+def test_shared_submitter_dialog_accepts_an_app_root():
+    app = MagicMock(spec=xa11y.App)
+    button = MagicMock()
+    app.locator.return_value = button
+    page = SharedSubmitterDialog(app)
+
+    result = page.button("Submit")
+
+    assert result is button
+    app.locator.assert_called_once_with('button[name="Submit"]')


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

DCC submitter UI tests need common infrastructure for running against an offline Deadline Cloud backend, interacting with the submitter through accessibility APIs, and validating exported job bundles and rendered images.

This infrastructure was implemented locally in the Cinema 4D integration tests, which made it difficult for other DCC integrations to reuse and maintain. The mock service also needs to run in a separate process because native accessibility waits can hold the test process's GIL and prevent an in-process server thread from responding.

### What was the solution? (How)

Added reusable DCC UI-testing components:

- `deadline_test_fixtures.deadline_mock`: a scenario-driven, observable Deadline REST-JSON mock service, an out-of-process server lifecycle, and helpers for creating isolated Deadline configuration and subprocess environments.
- `deadline_test_fixtures.xa11y`: cross-platform application discovery, common Qt accessibility controls, and a shared submitter dialog page object.
- `deadline_test_fixtures.job_bundle`: test-case directory management, completed-bundle discovery, OpenJD validation, and structural bundle comparison with configurable normalization.
- `deadline_test_fixtures.images`: rendered-image comparison with dimension and pixel-tolerance checks.

The README now documents these components and shows how a DCC can launch a submitter against the mock service. Unit tests were added for the mock backend and process lifecycle, configuration helpers, accessibility discovery, bundle comparison, and image comparison.

### What is the impact of this change?

Other DCC integrations can reuse the common test infrastructure while retaining responsibility for DCC-specific application launch, plugin setup, selectors, and scene creation.

The standard package installation now includes `xa11y`, `PyYAML`, `numpy`, `Pillow`, and `openjd-cli`. Existing APIs are unchanged.

### How was this change tested?

- `hatch run test`: 141 passed, 5 skipped.
- `hatch run lint`: Ruff, Black, and mypy passed.
- `hatch build`: the source distribution and wheel built successfully, and the wheel contains the new modules.
- The consuming Cinema 4D unit suite passed with 330 tests passed and 6 skipped after adopting the shared package APIs.
- The full Cinema 4D xa11y integration test passed end to end: `test_integ[cube]` completed in 33.99 seconds.

```
test/integ_xa11y/test_cinema4d.py::test_integ[cube] 
[gw0] [100%] PASSED test/integ_xa11y/test_cinema4d.py::test_integ[cube] 

============================================ slowest 5 durations ============================================
33.04s call     test/integ_xa11y/test_cinema4d.py::test_integ[cube]
0.28s setup    test/integ_xa11y/test_cinema4d.py::test_integ[cube]
0.00s teardown test/integ_xa11y/test_cinema4d.py::test_integ[cube]
============================================ 1 passed in 33.99s =============================================

```

### Was this change documented?

Yes. The README documents the new DCC UI-test components, their responsibilities, and an example offline mock-service setup.

### Is this a breaking change?

No. This change adds new public modules and dependencies without removing or changing existing APIs.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
