### PR TITLE
feat: add session_runtime passthrough to DeadlineWorkerConfiguration

### DIFF
--- a/src/deadline_test_fixtures/deadline/worker.py
+++ b/src/deadline_test_fixtures/deadline/worker.py
@@ -38,6 +38,16 @@ DEFAULT_WAITER_CONFIG = {
     "MaxAttempts": 30,
 }
 
+_VALID_SESSION_RUNTIMES = ("python", "rust", "service-selected")
+
+
+def _validate_session_runtime(value: str) -> None:
+    """Validate session_runtime before interpolating into shell commands."""
+    if value not in _VALID_SESSION_RUNTIMES:
+        raise ValueError(
+            f"Invalid session_runtime: {value!r}; " f"expected one of {_VALID_SESSION_RUNTIMES!r}"
+        )
+
 
 @dataclass
 class Ec2Tag:
@@ -165,6 +175,10 @@ class DeadlineWorkerConfiguration:
 
     session_root_dir: str | None = None
     """Path to parent directory of worker session directories"""
+
+    session_runtime: str | None = None
+    """Worker agent session_runtime setting (worker.toml [worker] section).
+    Valid values: "python", "rust", "service-selected"."""
 
     worker_env_var: Dict[str, str] | None = None
     """Additional feature flag to configure for workers"""
@@ -833,6 +847,11 @@ class WindowsInstanceBuildWorker(WindowsInstanceWorkerBase):
     def configure_worker_command(self, *, config: DeadlineWorkerConfiguration) -> str:
         """Get the command to configure the Worker. This must be run as Administrator."""
 
+        if config.session_runtime:
+            raise NotImplementedError(
+                "session_runtime passthrough is not implemented for Windows workers"
+            )
+
         cmds = [
             "Set-PSDebug -trace 1",
             self.configure_worker_common(config=config),
@@ -1143,6 +1162,21 @@ class PosixInstanceBuildWorker(PosixInstanceWorkerBase):
             # fmt: on
             f"runuser --login {self.configuration.agent_user} --command 'echo \"source /opt/deadline/worker/bin/activate\" >> $HOME/.bashrc'",
         ]
+
+        # Activate session_runtime in worker.toml if specified.
+        # The installer writes a commented-out "# session_runtime = ..." line;
+        # sed uncomments and sets the desired value.
+        if config.session_runtime:
+            _validate_session_runtime(config.session_runtime)
+            cmds.append(
+                f"sed -i 's/^# session_runtime = .*/session_runtime = \"{config.session_runtime}\"/' "
+                "/etc/amazon/deadline/worker.toml"
+                # sed exits 0 even when its pattern matches nothing, so a format drift in
+                # worker.toml.example would otherwise leave the worker silently on the default
+                # runtime; the grep makes that a loud setup failure.
+                f" && grep -q '^session_runtime = \"{config.session_runtime}\"' "
+                "/etc/amazon/deadline/worker.toml"
+            )
 
         for job_user in self.configuration.job_users:
             cmds.append(f"usermod -a -G {job_user.group} {self.configuration.agent_user}")

--- a/test/unit/deadline/test_worker.py
+++ b/test/unit/deadline/test_worker.py
@@ -22,6 +22,7 @@ from deadline_test_fixtures import (
     PipInstall,
     PosixInstanceBuildWorker,
     S3Object,
+    WindowsInstanceBuildWorker,
 )
 from deadline_test_fixtures.deadline import worker as mod
 
@@ -688,3 +689,191 @@ class TestDockerContainerWorker:
 
         # THEN
         assert result == worker_id
+
+
+class TestSessionRuntimePassthrough:
+    """Tests for session_runtime field passthrough in configure_worker_command."""
+
+    @pytest.fixture
+    def vpc_id(self) -> str:
+        return boto3.client("ec2").create_vpc(CidrBlock="10.0.0.0/28")["Vpc"]["VpcId"]
+
+    @pytest.fixture
+    def subnet_id(self, vpc_id: str) -> str:
+        return boto3.client("ec2").create_subnet(
+            VpcId=vpc_id,
+            CidrBlock="10.0.0.0/28",
+        )[
+            "Subnet"
+        ]["SubnetId"]
+
+    @pytest.fixture
+    def security_group_id(self, vpc_id: str) -> str:
+        return boto3.client("ec2").create_security_group(
+            VpcId=vpc_id,
+            Description="Testing",
+            GroupName="TestSG-Runtime",
+        )["GroupId"]
+
+    @pytest.fixture
+    def instance_profile_name(self) -> str:
+        return boto3.client("iam").create_instance_profile(
+            InstanceProfileName="instance-profile-runtime"
+        )["InstanceProfile"]["InstanceProfileName"]
+
+    @pytest.fixture
+    def bootstrap_bucket_name(self, region: str) -> str:
+        name = "bootstrap-bucket-runtime"
+        kwargs: dict[str, Any] = {"Bucket": name}
+        if region != "us-east-1":
+            kwargs["CreateBucketConfiguration"] = {"LocationConstraint": region}
+        boto3.client("s3").create_bucket(**kwargs)
+        return name
+
+    @pytest.fixture
+    def base_config(self, region: str) -> DeadlineWorkerConfiguration:
+        return DeadlineWorkerConfiguration(
+            farm_id="farm-123",
+            fleet=Fleet(id="fleet-123", farm=Farm(id="farm-123")),
+            region=region,
+            allow_shutdown=False,
+            worker_agent_install=PipInstall(
+                requirement_specifiers=["deadline-cloud-worker-agent"],
+                codeartifact=CodeArtifactRepositoryInfo(
+                    region=region,
+                    domain="test-domain",
+                    domain_owner="123456789123",
+                    repository="test-repository",
+                ),
+            ),
+        )
+
+    @pytest.fixture
+    def posix_worker(
+        self,
+        base_config: DeadlineWorkerConfiguration,
+        subnet_id: str,
+        security_group_id: str,
+        instance_profile_name: str,
+        bootstrap_bucket_name: str,
+    ) -> PosixInstanceBuildWorker:
+        return PosixInstanceBuildWorker(
+            subnet_id=subnet_id,
+            security_group_id=security_group_id,
+            instance_profile_name=instance_profile_name,
+            bootstrap_bucket_name=bootstrap_bucket_name,
+            s3_client=boto3.client("s3"),
+            ec2_client=boto3.client("ec2"),
+            ssm_client=boto3.client("ssm"),
+            deadline_client=boto3.client("deadline"),
+            configuration=base_config,
+            instance_type="t3.micro",
+            instance_shutdown_behavior="terminate",
+        )
+
+    @pytest.fixture
+    def windows_worker(
+        self,
+        base_config: DeadlineWorkerConfiguration,
+        subnet_id: str,
+        security_group_id: str,
+        instance_profile_name: str,
+        bootstrap_bucket_name: str,
+    ) -> WindowsInstanceBuildWorker:
+        return WindowsInstanceBuildWorker(
+            subnet_id=subnet_id,
+            security_group_id=security_group_id,
+            instance_profile_name=instance_profile_name,
+            bootstrap_bucket_name=bootstrap_bucket_name,
+            s3_client=boto3.client("s3"),
+            ec2_client=boto3.client("ec2"),
+            ssm_client=boto3.client("ssm"),
+            deadline_client=boto3.client("deadline"),
+            configuration=base_config,
+            instance_type="t3.micro",
+            instance_shutdown_behavior="terminate",
+        )
+
+    def test_posix_command_contains_sed_when_session_runtime_set(
+        self, posix_worker: PosixInstanceBuildWorker, base_config: DeadlineWorkerConfiguration
+    ) -> None:
+        """When session_runtime is set, the command should contain a sed to update worker.toml."""
+        from dataclasses import replace
+
+        config_with_runtime = replace(base_config, session_runtime="rust")
+        cmd = posix_worker.configure_worker_command(config_with_runtime)
+
+        assert "sed" in cmd
+        assert "session_runtime" in cmd
+        assert "rust" in cmd
+
+    @pytest.mark.parametrize("runtime", ["python", "rust", "service-selected"])
+    def test_posix_command_contains_grep_verification_after_sed(
+        self,
+        posix_worker: PosixInstanceBuildWorker,
+        base_config: DeadlineWorkerConfiguration,
+        runtime: str,
+    ) -> None:
+        """The command must grep for the exact expected line after sed, so a no-op sed is loud."""
+        from dataclasses import replace
+
+        config_with_runtime = replace(base_config, session_runtime=runtime)
+        cmd = posix_worker.configure_worker_command(config_with_runtime)
+
+        expected_sed = (
+            f"sed -i 's/^# session_runtime = .*/session_runtime = \"{runtime}\"/' "
+            "/etc/amazon/deadline/worker.toml"
+        )
+        expected_grep = (
+            f"grep -q '^session_runtime = \"{runtime}\"' /etc/amazon/deadline/worker.toml"
+        )
+        assert expected_sed in cmd, f"Missing sed command in: {cmd}"
+        assert expected_grep in cmd, f"Missing grep verification in: {cmd}"
+
+        # grep must come after sed (both joined by ' && ')
+        sed_pos = cmd.index(expected_sed)
+        grep_pos = cmd.index(expected_grep)
+        assert grep_pos > sed_pos, "grep must follow sed in the command chain"
+
+    def test_posix_command_no_sed_when_session_runtime_none(
+        self, posix_worker: PosixInstanceBuildWorker, base_config: DeadlineWorkerConfiguration
+    ) -> None:
+        """When session_runtime is None (default), no sed command for session_runtime."""
+        cmd = posix_worker.configure_worker_command(base_config)
+
+        # The word "session_runtime" should NOT appear in the command
+        # (session_root_dir may appear but that's a different field)
+        assert "session_runtime" not in cmd
+
+    def test_windows_raises_not_implemented_when_session_runtime_set(
+        self,
+        windows_worker: WindowsInstanceBuildWorker,
+        base_config: DeadlineWorkerConfiguration,
+    ) -> None:
+        """Windows should raise NotImplementedError when session_runtime is set."""
+        from dataclasses import replace
+
+        config_with_runtime = replace(base_config, session_runtime="rust")
+        with pytest.raises(NotImplementedError, match="session_runtime"):
+            windows_worker.configure_worker_command(config=config_with_runtime)
+
+    def test_windows_fine_when_session_runtime_none(
+        self,
+        windows_worker: WindowsInstanceBuildWorker,
+        base_config: DeadlineWorkerConfiguration,
+    ) -> None:
+        """Windows should work normally when session_runtime is None."""
+        cmd = windows_worker.configure_worker_command(config=base_config)
+
+        # Should produce a valid command string without errors
+        assert "install-deadline-worker" in cmd
+
+    def test_posix_raises_on_invalid_session_runtime(
+        self, posix_worker: PosixInstanceBuildWorker, base_config: DeadlineWorkerConfiguration
+    ) -> None:
+        """Invalid session_runtime values should raise ValueError (shell-injection guard)."""
+        from dataclasses import replace
+
+        config_invalid = replace(base_config, session_runtime="'; rm -rf /; echo '")
+        with pytest.raises(ValueError, match="Invalid session_runtime"):
+            posix_worker.configure_worker_command(config_invalid)


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

The deadline-cloud-worker-agent has a `session_runtime` worker setting (`[worker]` section of worker.toml; values `"python"`, `"rust"`, `"service-selected"`) that selects the OpenJD session runtime backend. Its e2e test suite needs to deploy EC2 workers pinned to a specific runtime mode to validate per-runtime routing behavior on real infrastructure. There was no way to pass this setting through `DeadlineWorkerConfiguration`: `install-deadline-worker` exposes no flag for it, and the worker.toml it installs leaves the key commented out.

### What was the solution? (How)

- New optional field `session_runtime: str | None = None` on `DeadlineWorkerConfiguration` (default `None` = leave the worker's own default untouched).
- Linux (`PosixInstanceBuildWorker` setup command): when set, a `sed` uncomments and sets `session_runtime = "<value>"` in `/etc/amazon/deadline/worker.toml`, after `install-deadline-worker` creates the file and before the agent service starts. This mirrors how `install.sh` itself applies `telemetry_opt_out` via sed.
- The sed is immediately followed by a `grep` asserting the exact line landed in the file — if the commented-line format in the installed worker.toml ever drifts and the sed no-ops, worker setup fails loudly instead of deploying a silently misconfigured worker.
- The value is validated against the three supported strings before being interpolated into the shell command; anything else raises `ValueError`.
- Windows (`WindowsInstanceBuildWorker`): raises `NotImplementedError` when the field is set — failing loudly rather than deploying a worker that silently ignores the requested runtime. Windows support can follow when the Windows runtime e2e path is ready.

**Note on the sed approach:** the sed/grep pair encodes knowledge of the worker.toml commented-line format, which is owned by the worker agent repo. Longer term, an `install-deadline-worker --session-runtime` flag would eliminate this cross-repo coupling entirely, at which point the sed/grep can be deleted. Kept out of scope here since the installer CLI is customer-visible surface; the grep keeps any drift a loud setup failure in the meantime.

### What is the impact of this change?

None for existing consumers: the field defaults to `None`, which produces byte-identical setup commands to today. Consumers that opt in get workers deployed with the requested runtime mode, verified at setup time.

### How was this change tested?

- Unit tests (written red-first): the posix setup command contains the sed+grep when the field is set and does not when unset; the grep asserts the exact configured line for each of the three values; invalid values raise `ValueError`; Windows raises `NotImplementedError` when set and is unaffected when unset. Full suite: 148 passed, 5 skipped. Lint (ruff + black) clean.
- Exercised end-to-end from the worker agent repo via an editable install of this change: deployed real EC2 workers in `python`, `rust`, and `service-selected` modes; the installed worker.toml contained the configured value and the workers routed/failed as expected (runtime e2e module: 5 passed, 4 skipped; a prior full worker-agent e2e suite run with this fixture: 57 passed, 27 skipped, 0 failed).

### Was this change documented?

Yes — the new field is documented on `DeadlineWorkerConfiguration` alongside the existing fields, including the supported values and the Windows limitation.

### Is this a breaking change?

No. The field defaults to `None`, preserving existing behavior for all current consumers.