### PR TITLE
feat: implement session_runtime passthrough for Windows workers

### DIFF
--- a/src/deadline_test_fixtures/deadline/worker.py
+++ b/src/deadline_test_fixtures/deadline/worker.py
@@ -848,9 +848,7 @@ class WindowsInstanceBuildWorker(WindowsInstanceWorkerBase):
         """Get the command to configure the Worker. This must be run as Administrator."""
 
         if config.session_runtime:
-            raise NotImplementedError(
-                "session_runtime passthrough is not implemented for Windows workers"
-            )
+            _validate_session_runtime(config.session_runtime)
 
         cmds = [
             "Set-PSDebug -trace 1",
@@ -880,6 +878,26 @@ class WindowsInstanceBuildWorker(WindowsInstanceWorkerBase):
             ),
             # fmt: on
         ]
+
+        # Activate session_runtime in worker.toml if specified.
+        # The installer writes a commented-out "# session_runtime = ..." line;
+        # -replace uncomments and sets the desired value.
+        if config.session_runtime:
+            toml_path = r"C:\ProgramData\Amazon\Deadline\Config\worker.toml"
+            # -replace exits cleanly even when its pattern matches nothing, so a format
+            # drift in worker.toml.example would otherwise leave the worker silently on
+            # the default runtime; the Select-String makes that a loud setup failure.
+            cmds.append(
+                f"(Get-Content '{toml_path}') -replace"
+                f" '^# session_runtime = .*',"
+                f" 'session_runtime = \"{config.session_runtime}\"'"
+                f" | Set-Content '{toml_path}'"
+            )
+            cmds.append(
+                f"if (-not (Select-String -Path '{toml_path}'"
+                f" -Pattern '^session_runtime = \"{config.session_runtime}\"$' -Quiet))"
+                f" {{ throw 'session_runtime was not applied to worker.toml' }}"
+            )
 
         if config.service_model_path:
             cmds.append(

--- a/test/unit/deadline/test_worker.py
+++ b/test/unit/deadline/test_worker.py
@@ -845,28 +845,63 @@ class TestSessionRuntimePassthrough:
         # (session_root_dir may appear but that's a different field)
         assert "session_runtime" not in cmd
 
-    def test_windows_raises_not_implemented_when_session_runtime_set(
+    @pytest.mark.parametrize("runtime", ["python", "rust", "service-selected"])
+    def test_windows_command_contains_replace_when_session_runtime_set(
         self,
         windows_worker: WindowsInstanceBuildWorker,
         base_config: DeadlineWorkerConfiguration,
+        runtime: str,
     ) -> None:
-        """Windows should raise NotImplementedError when session_runtime is set."""
+        """When session_runtime is set, command should contain PowerShell -replace for worker.toml."""
         from dataclasses import replace
 
-        config_with_runtime = replace(base_config, session_runtime="rust")
-        with pytest.raises(NotImplementedError, match="session_runtime"):
-            windows_worker.configure_worker_command(config=config_with_runtime)
+        config_with_runtime = replace(base_config, session_runtime=runtime)
+        cmd = windows_worker.configure_worker_command(config=config_with_runtime)
 
-    def test_windows_fine_when_session_runtime_none(
+        toml_path = r"C:\ProgramData\Amazon\Deadline\Config\worker.toml"
+        assert toml_path in cmd, f"Missing worker.toml path in: {cmd}"
+        assert "-replace" in cmd, f"Missing -replace in: {cmd}"
+        assert f'session_runtime = "{runtime}"' in cmd, f"Missing session_runtime value in: {cmd}"
+
+    def test_windows_command_no_replace_when_session_runtime_none(
         self,
         windows_worker: WindowsInstanceBuildWorker,
         base_config: DeadlineWorkerConfiguration,
     ) -> None:
-        """Windows should work normally when session_runtime is None."""
+        """When session_runtime is None (default), no PowerShell replace for session_runtime."""
         cmd = windows_worker.configure_worker_command(config=base_config)
 
-        # Should produce a valid command string without errors
-        assert "install-deadline-worker" in cmd
+        assert "session_runtime" not in cmd
+
+    @pytest.mark.parametrize("runtime", ["python", "rust", "service-selected"])
+    def test_windows_command_contains_select_string_verification(
+        self,
+        windows_worker: WindowsInstanceBuildWorker,
+        base_config: DeadlineWorkerConfiguration,
+        runtime: str,
+    ) -> None:
+        """Command must verify the line was applied via Select-String, so a no-op is loud."""
+        from dataclasses import replace
+
+        config_with_runtime = replace(base_config, session_runtime=runtime)
+        cmd = windows_worker.configure_worker_command(config=config_with_runtime)
+
+        toml_path = r"C:\ProgramData\Amazon\Deadline\Config\worker.toml"
+        assert "Select-String" in cmd, f"Missing Select-String verification in: {cmd}"
+        assert toml_path in cmd
+        assert f'session_runtime = "{runtime}"' in cmd
+
+    def test_windows_raises_on_invalid_session_runtime(
+        self,
+        windows_worker: WindowsInstanceBuildWorker,
+        base_config: DeadlineWorkerConfiguration,
+    ) -> None:
+        """Invalid session_runtime values should raise ValueError (shared validator)."""
+        from dataclasses import replace
+
+        config_invalid = replace(base_config, session_runtime="'; powershell -c evil; echo '")
+        with pytest.raises(ValueError, match="Invalid session_runtime"):
+            windows_worker.configure_worker_command(config=config_invalid)
 
     def test_posix_raises_on_invalid_session_runtime(
         self, posix_worker: PosixInstanceBuildWorker, base_config: DeadlineWorkerConfiguration


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)

#310 added the `session_runtime` passthrough to `DeadlineWorkerConfiguration` for Linux workers only; setting the field on a Windows worker raised `NotImplementedError`. Review feedback on #310 asked for Windows support, since the worker agent ships generically for Windows. The worker agent's e2e suite now runs its runtime-selection scenarios on Windows workers as well, which requires this injection.

### What was the solution? (How)

- `WindowsInstanceBuildWorker.configure_worker_command`: replaced the `NotImplementedError` with a PowerShell equivalent of the Linux `sed` flow. `Get-Content` (line-by-line, not `-Raw`) plus a `^`-anchored `-replace` activates the commented-out `session_runtime` key in `C:\ProgramData\Amazon\Deadline\Config\worker.toml`, inserted after `install-deadline-worker` and before `Start-Service`. The Windows installer copies the same `worker.toml.example`, so the same commented line is present.
- Mirrors the Linux design point for point: the value is allowlist-validated against the three supported strings before interpolation, and a `Select-String -Quiet` check follows the replace, throwing when the expected line is absent. `-replace` exits cleanly even when its pattern matches nothing, so without that check a format drift in `worker.toml.example` would leave the worker silently on the default runtime.

### What is the impact of this change?

None for existing consumers: the field defaults to `None`, which produces byte-identical setup commands. Windows consumers now get the same behavior as Linux instead of a raise.

### How was this change tested?

- Unit tests mirroring the Linux ones: PowerShell replace present when set (parametrized over `python`, `rust`, `service-selected`), absent when unset, the `Select-String` verification asserted, and invalid values raising `ValueError`. Full suite: 155 passed, 5 skipped. Lint clean.
- Exercised end to end via an editable install from the worker agent repo: real Windows Server 2022 EC2 workers deployed in `python`, `rust`, and `service-selected` modes. The injected `worker.toml` took effect and workers routed or failed as configured. Runtime e2e module on Windows: 5 passed, 6 skipped. Full worker-agent e2e suite on Windows: 52 passed, 23 skipped, 0 failed. Linux full suite unaffected: 54 passed, 29 skipped, 0 failed.

### Was this change documented?

Yes. The `session_runtime` field docs on `DeadlineWorkerConfiguration` no longer carry a Windows limitation, and the injection sites carry comments explaining why the verification step exists.

### Is this a breaking change?

No.

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*